### PR TITLE
Fix vignette reference in `RunStep()`

### DIFF
--- a/R/Flag.R
+++ b/R/Flag.R
@@ -8,7 +8,7 @@
 #'
 #' @details
 #' This function provides a generalized framework for flagging sites as part of the
-#' GSM data model (see `vignette("DataModel")`).
+#' GSM data model (see `vignette("DataModel", package = "gsm.core")`).
 #'
 #' @section Data Specification:
 #' \code{Flag} is designed to support the input data (`dfAnalyzed`) from the `Analyze_Identity()`

--- a/R/RunStep.R
+++ b/R/RunStep.R
@@ -31,7 +31,7 @@
 #' @param lStep `list` single workflow step (typically pulled from `lWorkflow$steps`). Should
 #'   include the name of the function to run (`lStep$name`), name of the object where the function result should be saved (`lStep$output`) and configurable parameters (`lStep$params`) (if any)
 #' @param lData `list` a named list of domain level data frames.
-#' @param lSpec `list` a data specification containing required columns. See `vignette("gsm_extensions")`.
+#' @param lSpec `list` a data specification containing required columns. See `vignette("gsmExtensions", package = "gsm.core")`.
 #' @param lMeta `list` a named list of meta data.
 #'
 #' @examples

--- a/gsm.core.Rproj
+++ b/gsm.core.Rproj
@@ -15,3 +15,8 @@ LaTeX: pdfLaTeX
 
 AutoAppendNewline: Yes
 StripTrailingWhitespace: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace

--- a/man/Flag.Rd
+++ b/man/Flag.Rd
@@ -34,7 +34,7 @@ method is used.
 }
 \details{
 This function provides a generalized framework for flagging sites as part of the
-GSM data model (see \code{vignette("DataModel")}).
+GSM data model (see \code{vignette("DataModel", package = "gsm.core")}).
 }
 \section{Data Specification}{
 

--- a/man/RunStep.Rd
+++ b/man/RunStep.Rd
@@ -14,7 +14,7 @@ include the name of the function to run (\code{lStep$name}), name of the object 
 
 \item{lMeta}{\code{list} a named list of meta data.}
 
-\item{lSpec}{\code{list} a data specification containing required columns. See \code{vignette("gsm_extensions")}.}
+\item{lSpec}{\code{list} a data specification containing required columns. See \code{vignette("gsmExtensions", package = "gsm.core")}.}
 }
 \value{
 \code{list} containing the results of the \code{lStep$name} function call should contain \code{.$checks}


### PR DESCRIPTION
## Overview
I found a bad vignette call when looking for info about how we reference specs (for an enhancement in gsm.app's plugin system). I also standardized the use of `package = "gsm.core")` (only 2 places didn't have it).
