### PR TITLE
`gsm.core::Summarize` new parameter `vColumns`

### DIFF
--- a/R/Summarize.R
+++ b/R/Summarize.R
@@ -19,7 +19,8 @@
 #'
 #' @param dfFlagged data.frame in format produced by [Flag()].
 #' @param nMinDenominator `numeric` Specifies the minimum denominator required to return a `score` and calculate a `flag`. Default: NULL
-#'
+#' @param strColumns `character` Vector of column names to include in the summary data.frame. Default: c("GroupID", "GroupLevel", "Numerator", "Denominator", "Metric", "Score", "Flag")
+#' 
 #' @return Simplified finding data.frame with columns for GroupID, GroupType, Metric, Score, Flag
 #' when associated with a workflow.
 #'
@@ -34,7 +35,8 @@
 
 Summarize <- function(
   dfFlagged,
-  nMinDenominator = NULL
+  nMinDenominator = NULL,
+  strColumns = c("GroupID", "GroupLevel", "Numerator", "Denominator", "Metric", "Score", "Flag")
 ) {
   stop_if(cnd = !is.data.frame(dfFlagged), message = "dfFlagged is not a data frame")
   stop_if(
@@ -51,19 +53,7 @@ Summarize <- function(
   }
 
   dfSummary <- dfFlagged %>%
-    select(
-      any_of(
-        c(
-          "GroupID",
-          "GroupLevel",
-          "Numerator",
-          "Denominator",
-          "Metric",
-          "Score",
-          "Flag"
-        )
-      )
-    ) %>%
+    select(any_of(strColumns)) %>%
     arrange(desc(abs(.data$Metric))) %>%
     arrange(match(.data$Flag, c(2, -2, 1, -1, 0)))
 

--- a/R/Summarize.R
+++ b/R/Summarize.R
@@ -53,7 +53,7 @@ Summarize <- function(
   }
 
   dfSummary <- dfFlagged %>%
-    select(any_of(strColumns)) %>%
+    select(any_of(vColumns)) %>%
     arrange(desc(abs(.data$Metric))) %>%
     arrange(match(.data$Flag, c(2, -2, 1, -1, 0)))
 

--- a/R/Summarize.R
+++ b/R/Summarize.R
@@ -19,7 +19,7 @@
 #'
 #' @param dfFlagged data.frame in format produced by [Flag()].
 #' @param nMinDenominator `numeric` Specifies the minimum denominator required to return a `score` and calculate a `flag`. Default: NULL
-#' @param strColumns `character` Vector of column names to include in the summary data.frame. Default: c("GroupID", "GroupLevel", "Numerator", "Denominator", "Metric", "Score", "Flag")
+#' @param vColumns `character` Vector of column names to include in the summary data.frame. Default: c("GroupID", "GroupLevel", "Numerator", "Denominator", "Metric", "Score", "Flag")
 #' 
 #' @return Simplified finding data.frame with columns for GroupID, GroupType, Metric, Score, Flag
 #' when associated with a workflow.
@@ -36,7 +36,7 @@
 Summarize <- function(
   dfFlagged,
   nMinDenominator = NULL,
-  strColumns = c("GroupID", "GroupLevel", "Numerator", "Denominator", "Metric", "Score", "Flag")
+  vColumns = c("GroupID", "GroupLevel", "Numerator", "Denominator", "Metric", "Score", "Flag")
 ) {
   stop_if(cnd = !is.data.frame(dfFlagged), message = "dfFlagged is not a data frame")
   stop_if(

--- a/man/Summarize.Rd
+++ b/man/Summarize.Rd
@@ -7,7 +7,7 @@
 Summarize(
   dfFlagged,
   nMinDenominator = NULL,
-  strColumns = c("GroupID", "GroupLevel", "Numerator", "Denominator", "Metric", "Score",
+  vColumns = c("GroupID", "GroupLevel", "Numerator", "Denominator", "Metric", "Score",
     "Flag")
 )
 }
@@ -16,7 +16,7 @@ Summarize(
 
 \item{nMinDenominator}{\code{numeric} Specifies the minimum denominator required to return a \code{score} and calculate a \code{flag}. Default: NULL}
 
-\item{strColumns}{\code{character} Vector of column names to include in the summary data.frame. Default: c("GroupID", "GroupLevel", "Numerator", "Denominator", "Metric", "Score", "Flag")}
+\item{vColumns}{\code{character} Vector of column names to include in the summary data.frame. Default: c("GroupID", "GroupLevel", "Numerator", "Denominator", "Metric", "Score", "Flag")}
 }
 \value{
 Simplified finding data.frame with columns for GroupID, GroupType, Metric, Score, Flag

--- a/man/Summarize.Rd
+++ b/man/Summarize.Rd
@@ -4,12 +4,19 @@
 \alias{Summarize}
 \title{Make Summary Data Frame}
 \usage{
-Summarize(dfFlagged, nMinDenominator = NULL)
+Summarize(
+  dfFlagged,
+  nMinDenominator = NULL,
+  strColumns = c("GroupID", "GroupLevel", "Numerator", "Denominator", "Metric", "Score",
+    "Flag")
+)
 }
 \arguments{
 \item{dfFlagged}{data.frame in format produced by \code{\link[=Flag]{Flag()}}.}
 
 \item{nMinDenominator}{\code{numeric} Specifies the minimum denominator required to return a \code{score} and calculate a \code{flag}. Default: NULL}
+
+\item{strColumns}{\code{character} Vector of column names to include in the summary data.frame. Default: c("GroupID", "GroupLevel", "Numerator", "Denominator", "Metric", "Score", "Flag")}
 }
 \value{
 Simplified finding data.frame with columns for GroupID, GroupType, Metric, Score, Flag


### PR DESCRIPTION
## Overview

-`gsm.core::Summarize` new parameter `vColumns`


## Test Notes/Sample Code

```
dfTransformed <- Transform_Rate(analyticsInput)
dfAnalyzed <- Analyze_NormalApprox(dfTransformed)
dfFlagged <- Flag(dfAnalyzed)
dfSummary_default <- Summarize(dfFlagged)


dfSummary_optional <- Summarize(
   dfFlagged,
   vColumns = c("GroupID", "GroupLevel", "Numerator", "Denominator", "Metric", "Score", "Flag")
)
```

dfSummary_default and dfSummary_optional will be identical, but more columns can be included or excluded for modules that require more summary columns for charting.

## Connected Issues
[gsm.simaerep add info to tooltip](https://github.com/IMPALA-Consortium/gsm.simaerep/issues/14)

