### PR TITLE
Fix RunStep messages and Warnings in tests

### DIFF
--- a/R/RunQuery.R
+++ b/R/RunQuery.R
@@ -92,6 +92,7 @@ RunQuery <- function(strQuery, df, bUseSchema = FALSE, lColumnMapping = NULL) {
             numeric = "DOUBLE",
             integer = "INTEGER",
             character = "VARCHAR",
+            timestamp = "DATETIME",
             "VARCHAR"
           )
           glue("{mapping$source} {type}")

--- a/R/RunStep.R
+++ b/R/RunStep.R
@@ -123,7 +123,7 @@ RunStep <- function(lStep, lData, lMeta, lSpec = NULL) {
       # If the parameter value is a vector, pass the vector as is.
       LogMessage(
         level = "info",
-        message = "{paramName} = {paramVal}: Parameter is a vector. Passing as is.",
+        message = "{paramName} is of length {length(paramVal)}: Parameter is a vector. Passing as is.",
         cli_detail = "alert_info"
       )
     }

--- a/R/util-checkSpec.R
+++ b/R/util-checkSpec.R
@@ -69,8 +69,12 @@ CheckSpec <- function(lData, lSpec) {
       names(lSpec[[strDataFrame]]),
       function(so_far, x, idx) {
         if (!is.null(x$type) && idx %in% chrDataFrameColnames) {
+          # update timestamp to proper class
+          if (x$type == "timestamp") {
+            x$type <- c("POSIXct", "POSIXt")
+          }
           # check if data is the expected mode
-          res <- all(x$type %in% class(lData[[strDataFrame]][[idx]]))
+          res <- all(x$type == class(lData[[strDataFrame]][[idx]]))
           if (!res) {
             so_far <- c(so_far, idx)
           }

--- a/R/util-checkSpec.R
+++ b/R/util-checkSpec.R
@@ -70,7 +70,7 @@ CheckSpec <- function(lData, lSpec) {
       function(so_far, x, idx) {
         if (!is.null(x$type) && idx %in% chrDataFrameColnames) {
           # check if data is the expected mode
-          res <- all(x$type == class(lData[[strDataFrame]][[idx]]))
+          res <- all(x$type %in% class(lData[[strDataFrame]][[idx]]))
           if (!res) {
             so_far <- c(so_far, idx)
           }

--- a/tests/testthat/_snaps/util-checkSpec.md
+++ b/tests/testthat/_snaps/util-checkSpec.md
@@ -40,7 +40,7 @@
     Message
       > All 1 data.frame(s) in the spec are present in the data: reporting_results
       > All specified columns in reporting_results are in the expected format
-      > All 5 specified column(s) in the spec are present in the data: reporting_results$GroupID, reporting_results$GroupLevel, reporting_results$Numerator, reporting_results$Denominator, reporting_results$SnapshotDate
+      > All 6 specified column(s) in the spec are present in the data: reporting_results$GroupID, reporting_results$GroupLevel, reporting_results$Numerator, reporting_results$Denominator, reporting_results$SnapshotDate, reporting_results$SnapshotDateTime
 
 ---
 
@@ -52,7 +52,7 @@
       Warning:
       Not all columns of reporting_results in the spec are in the expected format, improperly formatted columns are: Numerator
     Message
-      > All 5 specified column(s) in the spec are present in the data: reporting_results$GroupID, reporting_results$GroupLevel, reporting_results$Numerator, reporting_results$Denominator, reporting_results$SnapshotDate
+      > All 6 specified column(s) in the spec are present in the data: reporting_results$GroupID, reporting_results$GroupLevel, reporting_results$Numerator, reporting_results$Denominator, reporting_results$SnapshotDate, reporting_results$SnapshotDateTime
 
 # skip column check when `_all` is specified
 

--- a/tests/testthat/test-Analyze_NormalApprox.R
+++ b/tests/testthat/test-Analyze_NormalApprox.R
@@ -21,7 +21,10 @@ test_that("binary output created as expected and has correct structure", {
 })
 
 test_that("rate output created as expected and has correct structure", {
-  dfTransformed <- Transform_Rate(analyticsInput)
+  expect_warning(
+    {dfTransformed <- Transform_Rate(analyticsInput)},
+    "value of 0 removed"
+  )
 
   rate <- quiet_Analyze_NormalApprox(dfTransformed, strType = "rate")
 

--- a/tests/testthat/test-Analyze_NormalApprox_PredictBounds.R
+++ b/tests/testthat/test-Analyze_NormalApprox_PredictBounds.R
@@ -1,5 +1,8 @@
 test_that("Analyze_NormalApprox_PredictBounds handles missing nStep correctly", {
-  dfTransformed <- Transform_Rate(analyticsInput)
+  expect_warning(
+    {dfTransformed <- Transform_Rate(analyticsInput)},
+    "value of 0 removed"
+  )
   expect_message(
     {
       dfBounds <- Analyze_NormalApprox_PredictBounds(dfTransformed)
@@ -9,7 +12,10 @@ test_that("Analyze_NormalApprox_PredictBounds handles missing nStep correctly", 
 })
 
 test_that("Analyze_NormalApprox_PredictBounds handles missing nStep for weird range", {
-  dfTransformed <- Transform_Rate(analyticsInput)
+  expect_warning(
+    {dfTransformed <- Transform_Rate(analyticsInput)},
+    "value of 0 removed"
+  )
   dfTransformed <- dfTransformed %>%
     dplyr::mutate(
       Denominator = .data$Denominator[[1]],
@@ -24,7 +30,10 @@ test_that("Analyze_NormalApprox_PredictBounds handles missing nStep for weird ra
 })
 
 test_that("Analyze_NormalApprox_PredictBounds handles missing vThreshold correctly", {
-  dfTransformed <- Transform_Rate(analyticsInput)
+  expect_warning(
+    {dfTransformed <- Transform_Rate(analyticsInput)},
+    "value of 0 removed"
+  )
 
   expect_message(
     {
@@ -40,7 +49,10 @@ test_that("Analyze_NormalApprox_PredictBounds handles missing vThreshold correct
 })
 
 test_that("Analyze_NormalApprox_PredictBounds processes data correctly", {
-  dfTransformed <- Transform_Rate(analyticsInput)
+  expect_warning(
+    {dfTransformed <- Transform_Rate(analyticsInput)},
+    "value of 0 removed"
+  )
 
   dfBounds <- quiet_Analyze_NormalApprox_PredictBounds(dfTransformed)
 
@@ -49,7 +61,10 @@ test_that("Analyze_NormalApprox_PredictBounds processes data correctly", {
 })
 
 test_that("Analyze_NormalApprox_PredictBounds handles edge cases for vThreshold", {
-  dfTransformed <- Transform_Rate(analyticsInput)
+  expect_warning(
+    {dfTransformed <- Transform_Rate(analyticsInput)},
+    "value of 0 removed"
+  )
 
   dfBounds <- quiet_Analyze_NormalApprox_PredictBounds(
     dfTransformed,

--- a/tests/testthat/test-RunStep.R
+++ b/tests/testthat/test-RunStep.R
@@ -35,6 +35,16 @@ test_that("Passes direct value parameters correctly", {
   expect_equal(result$y, "100")
 })
 
+test_that("Passes direct value vector parameters correctly", {
+  lStep <- list(name = "dummy_function", params = list(x = "meta1", y = c(1,2,3)))
+  lMeta <- list(meta1 = 200)
+
+  expect_message(RunStep(lStep, lData, lMeta), "y is of length 3")
+  result <- RunStep(lStep, lData, lMeta), "y is of length 3"
+  expect_equal(result$x, 200)
+  expect_equal(result$y, c(1,2,3))
+})
+
 test_that("Handles multiple parameters and function invocation correctly", {
   lStep <- list(name = "another_dummy_function", params = list(a = "meta1", b = "data1", c = "some_value"))
   lData <- list(data1 = 300)

--- a/tests/testthat/test-RunStep.R
+++ b/tests/testthat/test-RunStep.R
@@ -40,7 +40,7 @@ test_that("Passes direct value vector parameters correctly", {
   lMeta <- list(meta1 = 200)
 
   expect_message(RunStep(lStep, lData, lMeta), "y is of length 3")
-  result <- RunStep(lStep, lData, lMeta), "y is of length 3"
+  result <- RunStep(lStep, lData, lMeta)
   expect_equal(result$x, 200)
   expect_equal(result$y, c(1,2,3))
 })

--- a/tests/testthat/test-util-checkSpec.R
+++ b/tests/testthat/test-util-checkSpec.R
@@ -90,13 +90,16 @@ test_that("Multiple missing columns are correctly reported", {
 
 test_that("Validate column type works", {
   lData <- list(reporting_results = gsm.core::reportingResults)
+  lData$reporting_results$SnapshotDateTime <- paste0(lData$reporting_results$SnapshotDate, "T01:01:01") %>%
+    as.POSIXct(format = "%Y-%m-%dT%H:%M:%S")
   lSpec <- list(
     reporting_results = list(
       GroupID = list(type = "character"),
       GroupLevel = list(type = "character"),
       Numerator = list(type = "integer"),
       Denominator = list(type = "integer"),
-      SnapshotDate = list(type = "Date")
+      SnapshotDate = list(type = "Date"),
+      SnapshotDateTime = list(type = "timestamp")
     )
   )
   expect_snapshot(CheckSpec(lData, lSpec))
@@ -107,7 +110,8 @@ test_that("Validate column type works", {
       GroupLevel = list(type = "character"),
       Numerator = list(type = "character"),
       Denominator = list(type = "integer"),
-      SnapshotDate = list(type = "Date")
+      SnapshotDate = list(type = "Date"),
+      SnapshotDateTime = list(type = "timestamp")
     )
   )
   expect_snapshot(CheckSpec(lData, lSpec))

--- a/tests/testthat/test_Analyze_Identity.R
+++ b/tests/testthat/test_Analyze_Identity.R
@@ -1,4 +1,7 @@
-dfTransformed <- Transform_Rate(analyticsInput)
+expect_warning(
+  {dfTransformed <- Transform_Rate(analyticsInput)},
+  "value of 0 removed"
+)
 dfAnalyzed <- Analyze_Identity(dfTransformed)
 
 test_that("output created as expected and has correct structure", {

--- a/tests/testthat/test_Analyze_Poisson.R
+++ b/tests/testthat/test_Analyze_Poisson.R
@@ -1,5 +1,8 @@
 test_that("output created as expected and has correct structure", {
-  ae_prep <- Transform_Rate(analyticsInput) %>% suppressWarnings()
+  expect_warning(
+    {ae_prep <- Transform_Rate(analyticsInput)},
+    "value of 0 removed"
+  )
   ae_anly <- Analyze_Poisson(ae_prep)
   expect_true(is.data.frame(ae_anly))
   expect_equal(sort(unique(analyticsInput$GroupID[which(analyticsInput$Denominator != 0)])), sort(ae_anly$GroupID))
@@ -13,7 +16,10 @@ test_that("incorrect inputs throw errors", {
 
 
 test_that("error given if required column not found", {
-  ae_prep <- Transform_Rate(analyticsInput)
+  expect_warning(
+    {ae_prep <- Transform_Rate(analyticsInput)},
+    "value of 0 removed"
+  )
   expect_error(Analyze_Poisson(ae_prep %>% select(-GroupID)))
   expect_error(Analyze_Poisson(ae_prep %>% select(-N)))
   expect_error(Analyze_Poisson(ae_prep %>% select(-Numerator)))
@@ -23,14 +29,16 @@ test_that("error given if required column not found", {
 
 test_that("NA values are caught", {
   createNA <- function(x) {
-    df <- analyticsInput %>%
-      Transform_Rate() %>%
-      suppressWarnings()
+    expect_warning(
+      {df <- analyticsInput %>%
+      Transform_Rate()},
+      "value of 0 removed"
+    )
 
     df[[x]][1] <- NA
 
     Analyze_Poisson(df)
-  }
+    }
 
   expect_error(createNA("GroupID"))
 })

--- a/tests/testthat/test_RunQuery.R
+++ b/tests/testthat/test_RunQuery.R
@@ -88,7 +88,8 @@ test_that("RunQuery applies schema appropriately", {
     Name = c("John", "Jane", "Bob"),
     Age = c(25, 30, 35),
     Salary = c(50000, 60000, "70000"),
-    Birthday = c("1990-01-01", "1987-02-02", "1985-03-03")
+    Birthday = c("1990-01-01", "1987-02-02", "1985-03-03"),
+    Birthtime = c("1990-01-01 06:47:00", "1987-02-02T08:15:34", "1985-03-03")
   )
   lColumnMapping <- list(
     Name = list(
@@ -103,14 +104,18 @@ test_that("RunQuery applies schema appropriately", {
     Birthdate = list(
       type = "Date",
       source_col = "Birthday"
+    ),
+    Birthtime = list(
+      type = "timestamp"
     )
   )
 
   # Define the query and mapping
-  query <- "SELECT Name, Age, Salary, Birthday AS Birthdate FROM df WHERE Age >= 30"
+  query <- "SELECT Name, Age, Salary, Birthday AS Birthdate, Birthtime FROM df WHERE Age >= 30"
 
   # Call the RunQuery function and expect no error
   expect_no_error(result <- RunQuery(query, df, bUseSchema = T, lColumnMapping = lColumnMapping))
+  expect_equal(class(result$Birthtime), c("POSIXct", "POSIXt"))
   expect_equal(class(result$Birthdate), "Date")
   expect_equal(class(result$Salary), "integer")
   expect_equal(class(result$Age), "integer")


### PR DESCRIPTION
## Overview
<!--- What was done in the source branch -->
<!--- (i.e. bugfixes, feature additions, etc.) -->
Fixes three issues.
1. RunStep messages where the param was a vector no longer produces {length(vector)} messages, but instead indicates the length of the vector in the CLI message and passes through as expected.
2. Denominator of value 0 warnings in tests are caught via `expect_warning()` to clean up testing process
3. Add timestamp support to RunQuery

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes Gilead-BioStats/gsm.mapping#23 
- Closes Gilead-BioStats/gsm.mapping#21 
- Closes Gilead-BioStats/gsm.mapping#22 

