### PR TITLE
allow RunStep to run with no parameters

### DIFF
--- a/R/RunStep.R
+++ b/R/RunStep.R
@@ -62,6 +62,10 @@ RunStep <- function(lStep, lData, lMeta, lSpec = NULL) {
   # prepare parameter list inputs
   params <- lStep$params
 
+  # to make sure do.call can be invoked even if no params are provided in the step
+  if (is.null(params)) {
+    params <- list()
+  }
   LogMessage(
     level = "info",
     message = "Evaluating {length(params)} parameter(s) for `{lStep$name}`",

--- a/tests/testthat/test-RunStep.R
+++ b/tests/testthat/test-RunStep.R
@@ -63,3 +63,13 @@ test_that("RunStep will run a function without a namespace", {
   result <- RunStep(lStep, lData, lMeta)
   expect_equal(result, head(Theoph))
 })
+
+test_that("RunStep will run a function with no parameters", {
+  output_data <- list(x = 1, output = "fake.html")
+  fake_func <- function() {
+    return(output_data)
+  }
+  lStep <- list(name = "fake_func")
+  result <- RunStep(lStep, list(), list())
+  expect_equal(result, output_data)
+})

--- a/tests/testthat/test-RunStep.R
+++ b/tests/testthat/test-RunStep.R
@@ -65,11 +65,9 @@ test_that("RunStep will run a function without a namespace", {
 })
 
 test_that("RunStep will run a function with no parameters", {
-  output_data <- list(x = 1, output = "fake.html")
-  fake_func <- function() {
-    return(output_data)
-  }
-  lStep <- list(name = "fake_func")
+  wd_path <- getwd()
+
+  lStep <- list(name = "getwd")
   result <- RunStep(lStep, list(), list())
-  expect_equal(result, output_data)
+  expect_equal(result, wd_path)
 })


### PR DESCRIPTION
fixes #31

@jwildfire @lauramaxwell basic tweak needed for custom reporting. Will need to discuss offline some other additions that might be relevant for gsm.core or might need to stay private for the time being.