### PR TITLE
update RunQuery to handle logical fields properly

### DIFF
--- a/R/RunQuery.R
+++ b/R/RunQuery.R
@@ -93,6 +93,7 @@ RunQuery <- function(strQuery, df, bUseSchema = FALSE, lColumnMapping = NULL) {
             integer = "INTEGER",
             character = "VARCHAR",
             timestamp = "DATETIME",
+            logical = "BOOLEAN",
             "VARCHAR"
           )
           glue("{mapping$source} {type}")

--- a/tests/testthat/test_RunQuery.R
+++ b/tests/testthat/test_RunQuery.R
@@ -89,7 +89,8 @@ test_that("RunQuery applies schema appropriately", {
     Age = c(25, 30, 35),
     Salary = c(50000, 60000, "70000"),
     Birthday = c("1990-01-01", "1987-02-02", "1985-03-03"),
-    Birthtime = c("1990-01-01 06:47:00", "1987-02-02T08:15:34", "1985-03-03")
+    Birthtime = c("1990-01-01 06:47:00", "1987-02-02T08:15:34", "1985-03-03"),
+    Tenured = c(FALSE, TRUE, TRUE)
   )
   lColumnMapping <- list(
     Name = list(
@@ -107,11 +108,14 @@ test_that("RunQuery applies schema appropriately", {
     ),
     Birthtime = list(
       type = "timestamp"
+    ),
+    Tenured = list(
+      type = "logical"
     )
   )
 
   # Define the query and mapping
-  query <- "SELECT Name, Age, Salary, Birthday AS Birthdate, Birthtime FROM df WHERE Age >= 30"
+  query <- "SELECT Name, Age, Salary, Birthday AS Birthdate, Birthtime, Tenured FROM df WHERE Age >= 30"
 
   # Call the RunQuery function and expect no error
   expect_no_error(result <- RunQuery(query, df, bUseSchema = T, lColumnMapping = lColumnMapping))
@@ -120,6 +124,7 @@ test_that("RunQuery applies schema appropriately", {
   expect_equal(class(result$Salary), "integer")
   expect_equal(class(result$Age), "integer")
   expect_equal(class(result$Name), "character")
+  expect_equal(class(result$Tenured), "logical")
 })
 
 test_that("RunQuery applies incomplete schema appropriately", {


### PR DESCRIPTION
## Overview
<!--- What was done in the source branch -->
<!--- (i.e. bugfixes, feature additions, etc.) -->
currently logical columns get passed to duckdb as VARCHAR, which causes problems with the results of the query, so this PR adds `logical` type columns to be handled by `RunQuery()` and passed to DuckDB as `BOOLEAN`

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #XXX

