### PR TITLE
Closes #44 maps noncompliant values of date/timestamp to NA

### DIFF
--- a/R/RunQuery.R
+++ b/R/RunQuery.R
@@ -107,8 +107,6 @@ RunQuery <- function(strQuery, df, bUseSchema = FALSE, lColumnMapping = NULL) {
         # need this to be an unnamed vector to avoid using target colnames here
         map_chr(lColumnMapping, function(x) x$source) %>% unname()
       )
-      # Sanitize Date and timestamp columns
-      library(purrr)
 
       # Sanitize Date and timestamp columns
       for (mapping in lColumnMapping) {

--- a/R/RunQuery.R
+++ b/R/RunQuery.R
@@ -107,6 +107,38 @@ RunQuery <- function(strQuery, df, bUseSchema = FALSE, lColumnMapping = NULL) {
         # need this to be an unnamed vector to avoid using target colnames here
         map_chr(lColumnMapping, function(x) x$source) %>% unname()
       )
+      # Sanitize Date and timestamp columns
+      library(purrr)
+
+      # Sanitize Date and timestamp columns
+      for (mapping in lColumnMapping) {
+        if (mapping$type %in% c("Date", "timestamp") && mapping$source %in% names(df)) {
+          raw_vals <- df[[mapping$source]]
+
+          if (!inherits(raw_vals, mapping$type)) {
+            parsed <- map(raw_vals, ~ tryCatch(
+              as.POSIXct(.x, tz = "UTC"),
+              error = function(e) NA_real_
+            ))
+
+            parsed <- flatten_dbl(parsed) %>% as.POSIXct(origin = "1970-01-01", tz = "UTC")
+
+            if (mapping$type == "Date") {
+              parsed <- as.Date(parsed)
+            }
+
+            n_bad <- sum(!is.na(raw_vals) & is.na(parsed))
+            if (n_bad > 0) {
+              LogMessage(
+                level = "warn",
+                message = glue("Field `{mapping$source}`: {n_bad} unparsable {mapping$type}(s) set to NA")
+              )
+            }
+
+            df[[mapping$source]] <- parsed
+          }
+        }
+      }
     }
     DBI::dbWriteTable(con, temp_table_name, df, append = append_tab)
     table_name <- temp_table_name

--- a/R/RunQuery.R
+++ b/R/RunQuery.R
@@ -113,7 +113,8 @@ RunQuery <- function(strQuery, df, bUseSchema = FALSE, lColumnMapping = NULL) {
         if (mapping$type %in% c("Date", "timestamp") && mapping$source %in% names(df)) {
           raw_vals <- df[[mapping$source]]
 
-          if (!inherits(raw_vals, mapping$type)) {
+          if ((mapping$type == "timestamp" && !inherits(raw_vals, c("POSIXct", "POSIXt"))) ||
+              (mapping$type != "timestamp" && !inherits(raw_vals, mapping$type))) {
             parsed <- map(raw_vals, ~ tryCatch(
               as.POSIXct(.x, tz = "UTC"),
               error = function(e) NA_real_

--- a/tests/testthat/test-RunQuery.R
+++ b/tests/testthat/test-RunQuery.R
@@ -154,3 +154,40 @@ test_that("RunQuery applies incomplete schema appropriately", {
   })
   expect_equal(class(result$emaN), "character")
 })
+
+
+test_that("RunQuery parses invalid date/times correctly", {
+  df <- data.frame(
+    Name = c("John", "Jane", "Bob"),
+    Birthday = c("1990JAN01", "1987-02-30", ""),
+    Birthtime = c("1990-01-32 06:47", "28FEB1987 01:45:32", ""),
+    Tenured = c(FALSE, TRUE, TRUE)
+  )
+  lColumnMapping <- list(
+    Name = list(
+      type = "character"
+    ),
+    Birthday = list(
+      type = "Date"
+    ),
+    Birthtime = list(
+      type = "timestamp"
+    )
+  )
+
+  # Define the query and mapping
+  query <- "SELECT * FROM df"
+
+  suppressWarnings(
+    suppressMessages(
+      result <- RunQuery(
+        query,
+        df,
+        bUseSchema = T,
+        lColumnMapping = lColumnMapping
+      )
+    )
+  )
+  expect_true(all(is.na(result$Birthday)))
+  expect_true(all(is.na(result$Birthtime)))
+})


### PR DESCRIPTION
## Overview
Closes #44 address `RunQuery()` to write noncompliant elements of date/timestamp to `NA`

Hey @samussiah try this branch with this:
```
basic_sim <- gsm.datasim::generate_rawdata_for_single_study(
  SnapshotCount = 1,
  SnapshotWidth = "months",
  ParticipantCount = 1000,
  SiteCount = 150,
  StudyID = "AA-AA-000-0000",
  workflow_path = "workflow/1_mappings",
  mappings = c("SUBJ", "PD"),
  package = "gsm.mapping",
  desired_specs = NULL
)
basic_sim[[1]]$Raw_PD$deviationdate <- as.character(basic_sim[[1]]$Raw_PD$deviationdate)
basic_sim[[1]]$Raw_PD$deviationdate[1:3] <- c("", "01/32/2024", "24DEC2024")
mappings_wf <- gsm.core::MakeWorkflowList(strNames = c("SUBJ", "PD"), strPath = "workflow/1_mappings", strPackage = "gsm.mapping")
mappings_spec <- gsm.mapping::CombineSpecs(mappings_wf)
lRaw <- gsm.mapping::Ingest(basic_sim[[1]], mappings_spec)
```
