### PR TITLE
Closes #67 surround `RunWorkflows()` with tryCatch to allow object to finish without error-ing out if one part of workflow breaks

### DIFF
--- a/R/RunWorkflows.R
+++ b/R/RunWorkflows.R
@@ -50,11 +50,7 @@ RunWorkflows <- function(
         )
       },
       error = function(e) {
-        LogMessage(
-          level = "warn",
-          message = glue::glue("Issue with {wf$meta$ID}: ", {conditionMessage(e)}),
-          cli_detail = "warn"
-        )
+        message(glue::glue("Issue with {wf$meta$ID}: ", {conditionMessage(e)}))
         NULL  # or return a list with an error field if needed
       }
     )

--- a/R/RunWorkflows.R
+++ b/R/RunWorkflows.R
@@ -50,7 +50,7 @@ RunWorkflows <- function(
         )
       },
       error = function(e) {
-        message(glue::glue("Issue with {wf$meta$ID}: ", {conditionMessage(e)}))
+        message(glue::glue("Error with {wf$meta$ID}: ", {conditionMessage(e)}))
         NULL  # or return a list with an error field if needed
       }
     )

--- a/R/RunWorkflows.R
+++ b/R/RunWorkflows.R
@@ -39,7 +39,7 @@ RunWorkflows <- function(
 
   lResults <- list()
   for (wf in lWorkflows) {
-    lResult <-   tryCatch(
+    lResult <- tryCatch(
       {
         RunWorkflow(
           lWorkflow = wf,
@@ -50,7 +50,11 @@ RunWorkflows <- function(
         )
       },
       error = function(e) {
-        message(glue::glue("Error in RunWorkflow {wf$meta$ID}: "), conditionMessage(e))
+        LogMessage(
+          level = "warn",
+          message = glue::glue("Issue with {wf$meta$ID}: ", {conditionMessage(e)}),
+          cli_detail = "warn"
+        )
         NULL  # or return a list with an error field if needed
       }
     )

--- a/R/RunWorkflows.R
+++ b/R/RunWorkflows.R
@@ -39,12 +39,20 @@ RunWorkflows <- function(
 
   lResults <- list()
   for (wf in lWorkflows) {
-    lResult <- RunWorkflow(
-      lWorkflow = wf,
-      lData = c(lResults, lData),
-      lConfig = lConfig,
-      bReturnResult = bReturnResult,
-      bKeepInputData = bKeepInputData
+    lResult <-   tryCatch(
+      {
+        RunWorkflow(
+          lWorkflow = wf,
+          lData = c(lResults, lData),
+          lConfig = lConfig,
+          bReturnResult = bReturnResult,
+          bKeepInputData = bKeepInputData
+        )
+      },
+      error = function(e) {
+        message(glue::glue("Error in RunWorkflow {wf$meta$ID}: "), conditionMessage(e))
+        NULL  # or return a list with an error field if needed
+      }
     )
 
     resultName <- strResultNames %>%

--- a/man/RunWorkflows.Rd
+++ b/man/RunWorkflows.Rd
@@ -10,6 +10,7 @@ RunWorkflows(
   lConfig = NULL,
   bKeepInputData = FALSE,
   bReturnResult = TRUE,
+  bLogFailAsError = TRUE,
   strResultNames = c("Type", "ID")
 )
 }
@@ -27,6 +28,8 @@ RunWorkflows(
 \item{bKeepInputData}{\code{boolean} should the input data be included in \code{lData} after the workflow is run? Only relevant when bReturnResult is FALSE. Default is \code{TRUE}.}
 
 \item{bReturnResult}{\code{boolean} should \emph{only} the result from the last step (\code{lResults}) be returned? If false, the full workflow (including \code{lResults}) is returned. Default is \code{TRUE}.}
+
+\item{bLogFailAsError}{\code{boolean} should a failed workflow be sent to ERROR level log or WARN? Default \code{TRUE} is sent to ERROR-level.}
 
 \item{strResultNames}{\code{string} vector of length two, which describes the meta fields used to name the output.}
 }

--- a/tests/testthat/_snaps/RunWorkflows.md
+++ b/tests/testthat/_snaps/RunWorkflows.md
@@ -1,0 +1,64 @@
+# Basic flow works
+
+    Code
+      RunWorkflows(test_wfs, lData = list(iris = iris))
+    Message
+      Failed workflow: test2: Force break
+    Output
+      $Mapped_test1
+         Sepal.Length Sepal.Width Petal.Length Petal.Width Species
+      1           5.1         3.5          1.4         0.2  setosa
+      2           4.9         3.0          1.4         0.2  setosa
+      3           4.7         3.2          1.3         0.2  setosa
+      4           4.6         3.1          1.5         0.2  setosa
+      5           5.0         3.6          1.4         0.2  setosa
+      6           5.4         3.9          1.7         0.4  setosa
+      7           4.6         3.4          1.4         0.3  setosa
+      8           5.0         3.4          1.5         0.2  setosa
+      9           4.4         2.9          1.4         0.2  setosa
+      10          4.9         3.1          1.5         0.1  setosa
+      11          5.4         3.7          1.5         0.2  setosa
+      12          4.8         3.4          1.6         0.2  setosa
+      13          4.8         3.0          1.4         0.1  setosa
+      14          4.3         3.0          1.1         0.1  setosa
+      15          5.8         4.0          1.2         0.2  setosa
+      16          5.7         4.4          1.5         0.4  setosa
+      17          5.4         3.9          1.3         0.4  setosa
+      18          5.1         3.5          1.4         0.3  setosa
+      19          5.7         3.8          1.7         0.3  setosa
+      20          5.1         3.8          1.5         0.3  setosa
+      21          5.4         3.4          1.7         0.2  setosa
+      22          5.1         3.7          1.5         0.4  setosa
+      23          4.6         3.6          1.0         0.2  setosa
+      24          5.1         3.3          1.7         0.5  setosa
+      25          4.8         3.4          1.9         0.2  setosa
+      26          5.0         3.0          1.6         0.2  setosa
+      27          5.0         3.4          1.6         0.4  setosa
+      28          5.2         3.5          1.5         0.2  setosa
+      29          5.2         3.4          1.4         0.2  setosa
+      30          4.7         3.2          1.6         0.2  setosa
+      31          4.8         3.1          1.6         0.2  setosa
+      32          5.4         3.4          1.5         0.4  setosa
+      33          5.2         4.1          1.5         0.1  setosa
+      34          5.5         4.2          1.4         0.2  setosa
+      35          4.9         3.1          1.5         0.2  setosa
+      36          5.0         3.2          1.2         0.2  setosa
+      37          5.5         3.5          1.3         0.2  setosa
+      38          4.9         3.6          1.4         0.1  setosa
+      39          4.4         3.0          1.3         0.2  setosa
+      40          5.1         3.4          1.5         0.2  setosa
+      41          5.0         3.5          1.3         0.3  setosa
+      42          4.5         2.3          1.3         0.3  setosa
+      43          4.4         3.2          1.3         0.2  setosa
+      44          5.0         3.5          1.6         0.6  setosa
+      45          5.1         3.8          1.9         0.4  setosa
+      46          4.8         3.0          1.4         0.3  setosa
+      47          5.1         3.8          1.6         0.2  setosa
+      48          4.6         3.2          1.4         0.2  setosa
+      49          5.3         3.7          1.5         0.2  setosa
+      50          5.0         3.3          1.4         0.2  setosa
+      
+      $Mapped_test2
+      [1] "Force break"
+      
+

--- a/tests/testthat/test-RunWorkflows.R
+++ b/tests/testthat/test-RunWorkflows.R
@@ -1,0 +1,10 @@
+test_wfs <- MakeWorkflowList(strPath = "testdata/misc")
+
+test_that("Basic flow works", {
+  logger <- logger("ERROR", appenders = console_appender(layout = cli_fmt))
+  SetLogger(logger)
+  expect_snapshot(RunWorkflows(test_wfs, lData = list(iris = iris)))
+})
+
+logger <- logger("DEBUG", appenders = console_appender(layout = cli_fmt))
+SetLogger(logger)

--- a/tests/testthat/testdata/misc/test1.yaml
+++ b/tests/testthat/testdata/misc/test1.yaml
@@ -1,0 +1,19 @@
+meta:
+  Type: Mapped
+  ID: test1
+  Description: testing workflows
+  Priority: 1
+spec:
+ iris:
+    Species:
+      required: true
+      type: character
+    Petal.Length:
+      required: true
+      type: numeric
+steps:
+  - output: setosa
+    name: gsm.core::RunQuery
+    params:
+      df: iris
+      strQuery: "SELECT * FROM df WHERE Species = 'setosa'"

--- a/tests/testthat/testdata/misc/test2.yaml
+++ b/tests/testthat/testdata/misc/test2.yaml
@@ -1,0 +1,18 @@
+meta:
+  Type: Mapped
+  ID: test2
+  Description: testing workflows
+  Priority: 1
+spec:
+ iris:
+    Species:
+      required: true
+      type: character
+    Petal.Length:
+      required: true
+      type: numeric
+steps:
+  - output: setosa
+    name: stop
+    params:
+      ...: "Force break"


### PR DESCRIPTION
## Overview
<!--- What was done in the source branch -->
<!--- (i.e. bugfixes, feature additions, etc.) -->

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #XXX

