### PR TITLE
Update RunQuery() to avoid type coersion

### DIFF
--- a/R/RunQuery.R
+++ b/R/RunQuery.R
@@ -93,7 +93,7 @@ RunQuery <- function(strQuery, df, bUseSchema = FALSE, lColumnMapping = NULL) {
             character = "VARCHAR",
             timestamp = "DATETIME",
             logical = "BOOLEAN",
-            "VARCHAR"
+            NULL
           )
           glue("{mapping$source} {type}")
         }) %>%

--- a/R/RunQuery.R
+++ b/R/RunQuery.R
@@ -51,7 +51,7 @@ RunQuery <- function(strQuery, df, bUseSchema = FALSE, lColumnMapping = NULL) {
         # through ApplySpec()
         mapping$source <- spec[["source"]] %||% spec[["source_col"]] %||% name
 
-        # NULL type breaks things below, so use existing type from `df` if not specified
+        # NULL type breaks things below, so use existing type from if not specified
         mapping$type <- spec[["type"]] %||% class(df[[mapping$source]])[1]
 
         return(mapping)
@@ -99,7 +99,7 @@ RunQuery <- function(strQuery, df, bUseSchema = FALSE, lColumnMapping = NULL) {
           if (is.null(type)) {
             LogMessage(
               level = "error",
-              message = "Unsupported type '{mapping$type}' for column '{mapping$source}'."
+              message = glue("Unsupported type '{mapping$type}' for column '{mapping$source}'.")
             )
           }
           glue("{mapping$source} {type}") %>%

--- a/R/RunQuery.R
+++ b/R/RunQuery.R
@@ -51,7 +51,7 @@ RunQuery <- function(strQuery, df, bUseSchema = FALSE, lColumnMapping = NULL) {
         # through ApplySpec()
         mapping$source <- spec[["source"]] %||% spec[["source_col"]] %||% name
 
-        # NULL type breaks things below, so use existing type if not specified
+        # NULL type breaks things below, so use existing type from `df` if not specified
         mapping$type <- spec[["type"]] %||% class(df[[mapping$source]])[1]
 
         return(mapping)

--- a/tests/testthat/test-RunQuery.R
+++ b/tests/testthat/test-RunQuery.R
@@ -142,6 +142,12 @@ test_that("RunQuery applies incomplete schema appropriately", {
   lColumnMapping <- list(
     emaN = list(
       source = "Name"
+    ),
+    Age = list(
+      type = "numeric"
+    ),
+    Salary = list(
+      type = "numeric"
     )
   )
 
@@ -152,7 +158,7 @@ test_that("RunQuery applies incomplete schema appropriately", {
       result <- RunQuery(query, df, bUseSchema = T, lColumnMapping = lColumnMapping)
     })
   })
-  expect_equal(class(result$emaN), "character")
+  expect_equal(class(result$emaN), class(df$Name))
 })
 
 


### PR DESCRIPTION
## Overview
<!--- What was done in the source branch -->
<!--- (i.e. bugfixes, feature additions, etc.) -->
Previously, to conform with DuckDBs requirement to specify a type wen creating a table, if a column type was not specified in the `spec`, it was coerced to `VARCHAR`. this causes problems with optional columns that are not `character` type, so this PR updates the type to inherit the type of the input `df` column and pass it to DuckDB if it is not specified in the spec.

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #71

