### PR TITLE
Add trigger releaser-workflow

### DIFF
--- a/.github/workflows/r-releaser.yaml
+++ b/.github/workflows/r-releaser.yaml
@@ -1,4 +1,4 @@
-name: R Releaser
+name: Release
 
 on:
   release:
@@ -10,66 +10,8 @@ on:
         required: true
 
 jobs:
-  release:
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-      pull-requests: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup R
-        uses: r-lib/actions/setup-r@v2
-
-      - name: get library path
-        id: library
-        run: |
-          OUTPUT=$(Rscript -e "cat(.libPaths()[1])")
-          echo "result=$OUTPUT" >> $GITHUB_OUTPUT
-          echo $GITHUB_OUTPUT
-
-      - name: Install package dependencies
-        run: |
-          Rscript -e "
-          options(repos = c(CRAN = 'https://packagemanager.posit.co/cran/__linux__/jammy/latest'))
-          install.packages( c('cli', 'DBI', 'dbplyr', 'dplyr', 'glue', 'lifecycle', 'log4r', 'magrittr', 'purrr', 'rlang', 'stats', 'tidyr', 'yaml'))
-          install.packages('https://packagemanager.posit.co/cran/__linux__/jammy/latest/src/contrib/duckdb_1.3.2.tar.gz?r_version=4.5&arch=x86_64', repos = NULL)
-          "
-
-      - name: Run R Releaser
-        id: releaser
-        uses: A2-ai/r-releaser/build-src@main
-        with:
-          library: ${{ steps.library.outputs.result }}
-          resave-data: false
-          md5: true
-          build-vignettes: false
-
-      - name: echo output
-        run: |
-          echo ${{ steps.releaser.outputs.tarball_path }}
-          echo ${{ steps.releaser.outputs.tarball_name }}
-
-      - name: Upload binaries to new release
-        if: github.event_name == 'release'
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ steps.releaser.outputs.tarball_path }}
-          asset_name: ${{ steps.releaser.outputs.tarball_name }}
-          tag: ${{ github.event.release.tag_name }}
-          overwrite: true
-        
-      - name: Upload binaries to existing release
-        if: github.event_name == 'workflow_dispatch'
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ steps.releaser.outputs.tarball_path }}
-          asset_name: ${{ steps.releaser.outputs.tarball_name }}
-          tag: ${{ inputs.tag }}
-          overwrite: true
+  call-release-workflow:
+    uses: Gilead-BioStats/gsm.utils/.github/workflows/r_releaser.yaml@releaser-workflow
+    with:
+      tag: ${{ github.event.release.tag_name || inputs.tag }}
+    secrets: inherit

--- a/.github/workflows/r-releaser.yaml
+++ b/.github/workflows/r-releaser.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   call-release-workflow:
-    uses: Gilead-BioStats/gsm.utils/.github/workflows/r_releaser.yaml@releaser-workflow
+    uses: Gilead-BioStats/gsm.utils/.github/workflows/r_releaser.yaml@main
     with:
       tag: ${{ github.event.release.tag_name || inputs.tag }}
     secrets: inherit


### PR DESCRIPTION
## Overview
This PR adds r-releaser trigger workflow to the core package that will trigger the reusable workflow located in the gsm.utils package. the workflow attaches a tarball of the source code to each release once it is tagged and released

Note: the tarball version in the release will have the version specified in the DESCRIPTION for the branch it runs on  

## Test Notes/Sample Code
The triggers include `on release creation` and on `workflow_dispatch`

## Connected Issues
- Closes #80 

