### PR TITLE
update Flag() to capture negative flags properly and add tests

### DIFF
--- a/R/Flag.R
+++ b/R/Flag.R
@@ -69,7 +69,7 @@ Flag <- function(
 
   dfFlagged <- dfAnalyzed
 
-  # generate flag values for dfAnalyzed[strColumn] based on vThresold and vFlag
+  # generate flag values for dfAnalyzed[strColumn] based on vThreshold and vFlag
   # Negative scores use right-closed intervals so a value exactly at a negative
   # threshold falls in the more extreme (lower) bucket. Non-negative scores use
   # left-closed intervals so a value exactly at a positive threshold falls in the

--- a/R/Flag.R
+++ b/R/Flag.R
@@ -70,15 +70,18 @@ Flag <- function(
   dfFlagged <- dfAnalyzed
 
   # generate flag values for dfAnalyzed[strColumn] based on vThresold and vFlag
-  dfFlagged$Flag <- cut(
-    dfFlagged[[strColumn]],
-    breaks = c(-Inf, vThreshold, Inf),
-    labels = vFlag,
-    right = FALSE,
-    include.lowest = TRUE
-  ) %>%
-    as.character() %>%
-    as.numeric() # Parse from factor to numeric
+  # Negative scores use right-closed intervals so a value exactly at a negative
+  # threshold falls in the more extreme (lower) bucket. Non-negative scores use
+  # left-closed intervals so a value exactly at a positive threshold falls in the
+  # more extreme (higher) bucket.
+  breaks <- c(-Inf, vThreshold, Inf)
+  col_vals <- dfFlagged[[strColumn]]
+  flag_idx <- ifelse(
+    col_vals < 0,
+    as.integer(cut(col_vals, breaks, right = TRUE, include.lowest = TRUE)),
+    as.integer(cut(col_vals, breaks, right = FALSE, include.lowest = TRUE))
+  )
+  dfFlagged$Flag <- vFlag[flag_idx]
 
   # filter to site with enough observations via AccrualThreshold and AccrualMetric
   if (!is.null(nAccrualThreshold) && !is.null(strAccrualMetric)) {

--- a/R/Flag.R
+++ b/R/Flag.R
@@ -74,7 +74,8 @@ Flag <- function(
     dfFlagged[[strColumn]],
     breaks = c(-Inf, vThreshold, Inf),
     labels = vFlag,
-    right = FALSE
+    right = FALSE,
+    include.lowest = TRUE
   ) %>%
     as.character() %>%
     as.numeric() # Parse from factor to numeric

--- a/tests/testthat/test-Flag.R
+++ b/tests/testthat/test-Flag.R
@@ -133,7 +133,7 @@ test_that("Flag function adds RiskScoreWeight info to Analysis_Flagged (#77)", {
   expect_equal(dfFlagged$Flag, expected_flags)
 })
 
-test_that("errors working as expected", {
+test_that("errors working as expected (#135)", {
   dfAnalyzed <- data.frame(
     GroupID = 1:12,
     Score = c(-4, -3.1, -3, -2.9, -2.1, -2, -1.9, 0, 2, 2.9, 3, 3.1)
@@ -158,4 +158,25 @@ test_that("errors working as expected", {
     Flag(dfAnalyzed, vRiskScoreWeight = c(1, 2, 3)),
     "vFlag and vRiskScoreWeight must be the same length"
   )
+})
+
+test_that("Flag correctly handles exact cut point values (include.lowest = TRUE) (#135)", {
+  # With right = FALSE, intervals are [lo, hi). A score exactly at a negative threshold
+  # falls in the left-closed interval starting at that threshold, so it receives a negative
+  # (non-zero) flag rather than NA. include.lowest = TRUE additionally ensures Inf maps to
+  # the highest flag instead of NA.
+  dfAnalyzed <- data.frame(
+    GroupID = 1:6,
+    Score = c(-Inf, -3, -2, 2, 3, Inf)
+  )
+
+  dfFlagged <- Flag(dfAnalyzed, vFlagOrder = NULL)
+
+  # -Inf: left endpoint of [-Inf, -3) → flag -2 (most negative)
+  # -3:   left endpoint of [-3, -2)   → flag -1 (negative, i.e. flagged, not NA)
+  # -2:   left endpoint of [-2,  2)   → flag  0
+  #  2:   left endpoint of [ 2,  3)   → flag  1
+  #  3:   left endpoint of [ 3, Inf)  → flag  2
+  # Inf:  include.lowest = TRUE closes [3, Inf] → flag  2 (not NA)
+  expect_equal(dfFlagged$Flag, c(-2, -1, 0, 1, 2, 2))
 })

--- a/tests/testthat/test-Flag.R
+++ b/tests/testthat/test-Flag.R
@@ -6,7 +6,7 @@ test_that("Flag function works correctly with z-score data", {
 
   # unsorted
   dfFlagged <- Flag(dfAnalyzed, vFlagOrder = NULL)
-  expect_equal(dfFlagged$Flag, c(-2, -2, -1, -1, -1, 0, 0, 0, 1, 1, 2, 2))
+  expect_equal(dfFlagged$Flag, c(-2, -2, -2, -1, -1, -1, 0, 0, 1, 1, 2, 2))
 
   # sorted
   expect_message(
@@ -15,15 +15,15 @@ test_that("Flag function works correctly with z-score data", {
     },
     "Sorted dfFlagged using custom Flag order"
   )
-  expect_equal(dfFlagged$Flag, c(2, 2, -2, -2, 1, 1, -1, -1, -1, 0, 0, 0))
+  expect_equal(dfFlagged$Flag, c(2, 2, -2, -2, -2, 1, 1, -1, -1, -1, 0, 0))
 
   # Test with custom thresholds and flags
   dfFlagged <- Flag(dfAnalyzed, vThreshold = c(-2, 2), vFlag = c(-1, 0, 1), vFlagOrder = NULL)
-  expect_equal(dfFlagged$Flag, c(-1, -1, -1, -1, -1, 0, 0, 0, 1, 1, 1, 1))
+  expect_equal(dfFlagged$Flag, c(-1, -1, -1, -1, -1, -1, 0, 0, 1, 1, 1, 1))
 
   # Test Alias
   dfFlagged <- Flag_NormalApprox(dfAnalyzed, vFlagOrder = NULL)
-  expect_equal(dfFlagged$Flag, c(-2, -2, -1, -1, -1, 0, 0, 0, 1, 1, 2, 2))
+  expect_equal(dfFlagged$Flag, c(-2, -2, -2, -1, -1, -1, 0, 0, 1, 1, 2, 2))
 })
 
 test_that("Flag function works correctly with rate data", {
@@ -160,11 +160,12 @@ test_that("errors working as expected (#135)", {
   )
 })
 
-test_that("Flag correctly handles exact cut point values (include.lowest = TRUE) (#135)", {
-  # With right = FALSE, intervals are [lo, hi). A score exactly at a negative threshold
-  # falls in the left-closed interval starting at that threshold, so it receives a negative
-  # (non-zero) flag rather than NA. include.lowest = TRUE additionally ensures Inf maps to
-  # the highest flag instead of NA.
+test_that("Flag correctly handles exact cut point values at negative and positive thresholds", {
+  # Values exactly at a negative threshold fall in the more extreme (lower) bucket
+  # because right-closed intervals are used for negative scores: (-Inf, t].
+  # Values exactly at a positive threshold fall in the more extreme (higher) bucket
+  # because left-closed intervals are used for non-negative scores: [t, Inf).
+  # include.lowest = TRUE ensures -Inf and Inf are also captured rather than returning NA.
   dfAnalyzed <- data.frame(
     GroupID = 1:6,
     Score = c(-Inf, -3, -2, 2, 3, Inf)
@@ -172,11 +173,11 @@ test_that("Flag correctly handles exact cut point values (include.lowest = TRUE)
 
   dfFlagged <- Flag(dfAnalyzed, vFlagOrder = NULL)
 
-  # -Inf: left endpoint of [-Inf, -3) → flag -2 (most negative)
-  # -3:   left endpoint of [-3, -2)   → flag -1 (negative, i.e. flagged, not NA)
-  # -2:   left endpoint of [-2,  2)   → flag  0
-  #  2:   left endpoint of [ 2,  3)   → flag  1
-  #  3:   left endpoint of [ 3, Inf)  → flag  2
-  # Inf:  include.lowest = TRUE closes [3, Inf] → flag  2 (not NA)
-  expect_equal(dfFlagged$Flag, c(-2, -1, 0, 1, 2, 2))
+  # -Inf: in (-Inf, -3] → flag -2
+  # -3:   in (-Inf, -3] → flag -2 (AT threshold, right-closed → more extreme)
+  # -2:   in (-3,  -2] → flag -1 (AT threshold, right-closed → more extreme)
+  #  2:   in [ 2,   3) → flag  1 (AT threshold, left-closed  → more extreme)
+  #  3:   in [ 3, Inf] → flag  2 (AT threshold, left-closed  → more extreme)
+  # Inf:  in [ 3, Inf] → flag  2 (include.lowest = TRUE, not NA)
+  expect_equal(dfFlagged$Flag, c(-2, -2, -1, 1, 2, 2))
 })

--- a/tests/testthat/test-Flag.R
+++ b/tests/testthat/test-Flag.R
@@ -160,7 +160,7 @@ test_that("errors working as expected (#135)", {
   )
 })
 
-test_that("Flag correctly handles exact cut point values at negative and positive thresholds", {
+test_that("Flag correctly handles exact cut point values at negative and positive thresholds (#135)", {
   # Values exactly at a negative threshold fall in the more extreme (lower) bucket
   # because right-closed intervals are used for negative scores: (-Inf, t].
   # Values exactly at a positive threshold fall in the more extreme (higher) bucket


### PR DESCRIPTION
## Overview
<!--- What was done in the source branch -->
<!--- (i.e. bugfixes, feature additions, etc.) -->
Update `cut()` call in `Flag()` to include negative values that land on the cut point, as they were previously excluded due to the `right = FALSE` logic. 

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->
new test in the `test-Flag.R` file

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #135

