### PR TITLE
Document the workflow contract for ecosystem packages (#145)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -191,6 +191,71 @@ These workflows are maintained in `gsm.utils` and deployed to all GSM packages.
 
 ---
 
+# Workflow Contract for Ecosystem Packages
+
+GSM ecosystem packages (e.g. `gsm.mapping`, `gsm.kri`, `gsm.reporting`, `gsm.endpoints`) ship analysis pipelines as workflow YAMLs. A snapshot tool ([`workr`](https://github.com/Gilead-BioStats/workr)) aggregates these YAMLs across every package into a single reusable library bundle (published via `gismo.library`), which downstream study repositories execute with `workr::RunProject()`.
+
+Because the bundle is a flat merge of many packages' workflows, every contributing package must follow the same conventions. This section is the **canonical contract**. It lives here in `gsm.core` (a public repo) so that maintainers of both public and private ecosystem packages — and downstream consumers — can read it. Private repos such as `gismo.library` should link back to this section rather than redefining it.
+
+## 1. Where workflow YAMLs live
+
+Place workflow YAMLs under **`inst/workflow/`** (singular) in your package:
+
+```
+your.package/
+└── inst/
+    └── workflow/
+        ├── 1_mappings/
+        ├── 2_metrics/
+        └── 3_reporting/
+```
+
+* Use the **singular** `inst/workflow/`. This is the canonical location workr looks for. (Historically some packages used `inst/workflows`, plural; workr now also tolerates the plural form per [Gilead-BioStats/workr#45](https://github.com/Gilead-BioStats/workr/issues/45), but new and migrated packages must use the singular form so the layout stays consistent.)
+* Only place actual workflow YAMLs here. Do not store unrelated package data under `inst/workflow/`.
+
+## 2. The numbered-folder (phase) convention
+
+Workflows are grouped into numbered phase directories. The aggregator merges the same-numbered folders from every package into one phase, and `RunProject()` executes phases in numeric order. Use exactly these names:
+
+| Folder | Phase | Contents |
+|---|---|---|
+| `0_other` | — (not a runnable phase) | Config / spec documents (e.g. study windows, flag specs). **Not** workflow-shaped — no executable `steps`. |
+| `1_mappings` | Mappings | `Mapped_*` data-mapping workflows (one per domain). |
+| `2_metrics` | Metrics | Metric / analysis workflows (e.g. `kri####`, `cou####`). |
+| `3_reporting` | Reporting | Reporting workflows that consume metric results. |
+| `4_modules` | — (not a runnable phase) | App module specs consumed by `gsm.app`, not executed by `RunProject()`. |
+
+Notes:
+
+* `0_other` and `4_modules` are **not runnable phases** — they hold specs/config, not workflows with `steps`. A bare `RunProject("workflows")` over all subdirectories will choke on them, so consumers must restrict the runnable phases. Keep non-runnable content in these two folders only; never mix config documents into `1_mappings`/`2_metrics`/`3_reporting`.
+* Do not invent new top-level numbered folders without coordinating across the ecosystem (raise an issue first) — the aggregator and `RunProject()` rely on this fixed set.
+
+## 3. Naming rules
+
+* **One workflow per file.** The filename is the workflow's identity within its phase.
+* Name files after the workflow's `meta: ID` / output, matching the established pattern for the phase:
+  * `1_mappings/` — the domain name, matching the `Mapped_*` output (e.g. `AE.yaml` → `Mapped_AE`, `SUBJ.yaml` → `Mapped_SUBJ`).
+  * `2_metrics/` — the metric ID (e.g. `kri0001.yaml`, `cou0015.yaml`, `end0001.yaml`).
+  * `3_reporting/` — the report name (e.g. `Metrics.yaml`, `Results.yaml`).
+* Every workflow YAML must declare a `meta:` block with at least `Type`, `ID`, and `Description` (mappings additionally set `Priority`).
+* **Fully qualify step functions** with their package namespace (e.g. `gsm.kri::Analyze_NormalApprox`, not bare `Analyze_NormalApprox`). The aggregated bundle is run outside your package's namespace, so unprefixed functions will not resolve at runtime.
+* Filenames are case-sensitive in the bundle — keep capitalization consistent with the convention above.
+
+## 4. Collision policy
+
+The aggregator flattens every package's `inst/workflow/<phase>/` contents into a single `workflows/<phase>/` tree **with no per-package namespace**. Therefore:
+
+* **A filename must be unique across the entire ecosystem within its phase folder.** If two packages each ship `2_metrics/foo.yaml`, they collide.
+* Per [Gilead-BioStats/workr#46](https://github.com/Gilead-BioStats/workr/issues/46), the aggregator now detects duplicate destination paths and warns (or fails, configurably) naming both source repos — but a collision still means one package's workflow is at risk of being dropped. **Do not rely on the warning; choose non-colliding names up front.**
+* Prefer package-distinctive prefixes for metric/report IDs (e.g. `kri####` from `gsm.kri`, `cou####`, `end####` from `gsm.endpoints`) so names stay disjoint as the ecosystem grows.
+* Before adding a new workflow, check the other ecosystem packages (and the latest `gismo.library` snapshot) for an existing file of the same name in the same phase.
+
+## 5. Private-package considerations
+
+If your package is private (e.g. `gsm.endpoints`) and its workflows call functions from private packages at runtime, the rendered bundle is not runnable by a consumer without org-read access to those packages. Document any such access requirement alongside the workflow, and coordinate with the `gismo.library` maintainers so private-package workflows can be partitioned appropriately.
+
+---
+
 # Appendix 1 – Quick Reference
 
 ### Fix Branch Workflow

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -193,9 +193,9 @@ These workflows are maintained in `gsm.utils` and deployed to all GSM packages.
 
 # Workflow Contract for Ecosystem Packages
 
-GSM ecosystem packages (e.g. `gsm.mapping`, `gsm.kri`, `gsm.reporting`, `gsm.endpoints`) ship analysis pipelines as workflow YAMLs. A snapshot tool ([`workr`](https://github.com/Gilead-BioStats/workr)) aggregates these YAMLs across every package into a single reusable library bundle (published via `gismo.library`), which downstream study repositories execute with `workr::RunProject()`.
+GSM ecosystem packages (e.g. `gsm.mapping`, `gsm.kri`, `gsm.reporting`, `gsm.endpoints`) ship reusable analysis pipelines as workflow YAMLs. These workflows are collected with workflows from other packages and run by downstream study projects with `workr::RunProject()`.
 
-Because the bundle is a flat merge of many packages' workflows, every contributing package must follow the same conventions. This section is the **canonical contract**. It lives here in `gsm.core` (a public repo) so that maintainers of both public and private ecosystem packages — and downstream consumers — can read it. Private repos such as `gismo.library` should link back to this section rather than redefining it.
+Because workflows from multiple packages are collected into shared phase folders, every contributing package must follow the same conventions.
 
 ## 1. Where workflow YAMLs live
 
@@ -210,32 +210,33 @@ your.package/
         └── 3_reporting/
 ```
 
-* Use the **singular** `inst/workflow/`. This is the canonical location workr looks for. (Historically some packages used `inst/workflows`, plural; workr now also tolerates the plural form per [Gilead-BioStats/workr#45](https://github.com/Gilead-BioStats/workr/issues/45), but new and migrated packages must use the singular form so the layout stays consistent.)
+* Use the **singular** `inst/workflow/`. This is the canonical location workr looks for.
 * Only place actual workflow YAMLs here. Do not store unrelated package data under `inst/workflow/`.
 
 ## 2. The numbered-folder (phase) convention
 
-Workflows are grouped into numbered phase directories. The aggregator merges the same-numbered folders from every package into one phase, and `RunProject()` executes phases in numeric order. Use exactly these names:
+Workflows are grouped into numbered phase directories. Use these names so packages compose predictably:
 
 | Folder | Phase | Contents |
 |---|---|---|
 | `0_other` | — (not a runnable phase) | Config / spec documents (e.g. study windows, flag specs). **Not** workflow-shaped — no executable `steps`. |
 | `1_mappings` | Mappings | `Mapped_*` data-mapping workflows (one per domain). |
-| `2_metrics` | Metrics | Metric / analysis workflows (e.g. `kri####`, `cou####`). |
+| `2_metrics` | Metrics | Metric / analysis workflows (e.g. `kri####`, `cou####`, `end####`). |
 | `3_reporting` | Reporting | Reporting workflows that consume metric results. |
 | `4_modules` | — (not a runnable phase) | App module specs consumed by `gsm.app`, not executed by `RunProject()`. |
 
 Notes:
 
-* `0_other` and `4_modules` are **not runnable phases** — they hold specs/config, not workflows with `steps`. A bare `RunProject("workflows")` over all subdirectories will choke on them, so consumers must restrict the runnable phases. Keep non-runnable content in these two folders only; never mix config documents into `1_mappings`/`2_metrics`/`3_reporting`.
-* Do not invent new top-level numbered folders without coordinating across the ecosystem (raise an issue first) — the aggregator and `RunProject()` rely on this fixed set.
+* `0_other` and `4_modules` are **not runnable phases** — they hold specs/config and app module definitions, not workflows with executable `steps`.
+* Runnable phase folders may include phase-level config files such as `_config.yml` when supported. Keep ordinary spec/config documents in the non-runnable folders.
+* Treat this folder set as the ecosystem convention. Coordinate before adding a new top-level numbered folder so snapshot and study workflows agree on phase order.
 
 ## 3. Naming rules
 
 * **One workflow per file.** The filename is the workflow's identity within its phase.
 * Name files after the workflow's `meta: ID` / output, matching the established pattern for the phase:
   * `1_mappings/` — the domain name, matching the `Mapped_*` output (e.g. `AE.yaml` → `Mapped_AE`, `SUBJ.yaml` → `Mapped_SUBJ`).
-  * `2_metrics/` — the metric ID (e.g. `kri0001.yaml`, `cou0015.yaml`, `end0001.yaml`).
+  * `2_metrics/` — the metric ID (e.g. `kri0001.yaml`, `end0001.yaml`).
   * `3_reporting/` — the report name (e.g. `Metrics.yaml`, `Results.yaml`).
 * Every workflow YAML must declare a `meta:` block with at least `Type`, `ID`, and `Description` (mappings additionally set `Priority`).
 * **Fully qualify step functions** with their package namespace (e.g. `gsm.kri::Analyze_NormalApprox`, not bare `Analyze_NormalApprox`). The aggregated bundle is run outside your package's namespace, so unprefixed functions will not resolve at runtime.
@@ -243,16 +244,15 @@ Notes:
 
 ## 4. Collision policy
 
-The aggregator flattens every package's `inst/workflow/<phase>/` contents into a single `workflows/<phase>/` tree **with no per-package namespace**. Therefore:
+Workflow files from every package are collected into the same phase folders. Therefore:
 
 * **A filename must be unique across the entire ecosystem within its phase folder.** If two packages each ship `2_metrics/foo.yaml`, they collide.
-* Per [Gilead-BioStats/workr#46](https://github.com/Gilead-BioStats/workr/issues/46), the aggregator now detects duplicate destination paths and warns (or fails, configurably) naming both source repos — but a collision still means one package's workflow is at risk of being dropped. **Do not rely on the warning; choose non-colliding names up front.**
-* Prefer package-distinctive prefixes for metric/report IDs (e.g. `kri####` from `gsm.kri`, `cou####`, `end####` from `gsm.endpoints`) so names stay disjoint as the ecosystem grows.
-* Before adding a new workflow, check the other ecosystem packages (and the latest `gismo.library` snapshot) for an existing file of the same name in the same phase.
+* Prefer package-distinctive prefixes for metric/report IDs (e.g. `kri####` from `gsm.kri`, `end####` from `gsm.endpoints`) so names stay disjoint as the ecosystem grows.
+* Before adding a new workflow, check the other ecosystem packages for an existing file of the same name in the same phase.
 
 ## 5. Private-package considerations
 
-If your package is private (e.g. `gsm.endpoints`) and its workflows call functions from private packages at runtime, the rendered bundle is not runnable by a consumer without org-read access to those packages. Document any such access requirement alongside the workflow, and coordinate with the `gismo.library` maintainers so private-package workflows can be partitioned appropriately.
+If your package is private (e.g. `gsm.endpoints`) and its workflows call functions from private packages at runtime, the workflow is not runnable by a consumer without access to those packages. Document any such access requirement alongside the workflow so consumers can choose an appropriate package set.
 
 ---
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,3 @@
-# gsm.core v1.2.2 (development version)
-
-- Document the workflow contract for ecosystem packages in `CONTRIBUTING.md` (workflow YAML location, numbered-phase convention, naming rules, and collision policy), with a pointer from the README (#145).
-
 # gsm.core v1.2.1
 
 This patch release updates the GitHub action workflows to align with the new federated action framework in `gsm.utils`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# gsm.core v1.2.2 (development version)
+
+- Document the workflow contract for ecosystem packages in `CONTRIBUTING.md` (workflow YAML location, numbered-phase convention, naming rules, and collision policy), with a pointer from the README (#145).
+
 # gsm.core v1.2.1
 
 This patch release updates the GitHub action workflows to align with the new federated action framework in `gsm.utils`

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Since {gsm.core} is designed for use in a [GCP](https://en.wikipedia.org/wiki/Go
 -   **Function Documentation** - Comprehensive roxygen2 documentation maintained for all functions.
 -   **Data Specifications** - Machine-readable specifications for all KRIs, automatically integrated into function documentation.
 -   **Contributor Guidelines** - Step-by-step processes for code development and releases provided in `CONTRIBUTING.md` and required to be followed for contributions.
+-   **Workflow Contract** - Conventions ecosystem packages must follow when shipping workflow YAMLs (location, numbered phases, naming, and collision rules) are documented in the [Workflow Contract for Ecosystem Packages](.github/CONTRIBUTING.md#workflow-contract-for-ecosystem-packages) section of `CONTRIBUTING.md`.
 
 ## Development Practices
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Since {gsm.core} is designed for use in a [GCP](https://en.wikipedia.org/wiki/Go
 
 -   **Function Documentation** - Comprehensive roxygen2 documentation maintained for all functions.
 -   **Data Specifications** - Machine-readable specifications for all KRIs, automatically integrated into function documentation.
--   **Contributor Guidelines** - Step-by-step processes for code development, releases, and workflow YAML conventions are provided in [CONTRIBUTING.md](.github/CONTRIBUTING.md) and required to be followed for contributions.
+-   **Contributor Guidelines** - Step-by-step processes for code development, releases, and workflow YAML conventions are provided in [CONTRIBUTING.md](.github/CONTRIBUTING.md) and must be followed for contributions.
 
 ## Development Practices
 

--- a/README.md
+++ b/README.md
@@ -153,8 +153,7 @@ Since {gsm.core} is designed for use in a [GCP](https://en.wikipedia.org/wiki/Go
 
 -   **Function Documentation** - Comprehensive roxygen2 documentation maintained for all functions.
 -   **Data Specifications** - Machine-readable specifications for all KRIs, automatically integrated into function documentation.
--   **Contributor Guidelines** - Step-by-step processes for code development and releases provided in `CONTRIBUTING.md` and required to be followed for contributions.
--   **Workflow Contract** - Conventions ecosystem packages must follow when shipping workflow YAMLs (location, numbered phases, naming, and collision rules) are documented in the [Workflow Contract for Ecosystem Packages](.github/CONTRIBUTING.md#workflow-contract-for-ecosystem-packages) section of `CONTRIBUTING.md`.
+-   **Contributor Guidelines** - Step-by-step processes for code development, releases, and workflow YAML conventions are provided in [CONTRIBUTING.md](.github/CONTRIBUTING.md) and required to be followed for contributions.
 
 ## Development Practices
 


### PR DESCRIPTION
## Overview

Adds a canonical **Workflow Contract for Ecosystem Packages** section to `.github/CONTRIBUTING.md`, documenting the rules ecosystem packages must follow when contributing workflow YAMLs that the `workr` snapshot tool aggregates into the `gismo.library` bundle. The contract lives in `gsm.core` (public) so both public and private ecosystem maintainers — and downstream consumers — can read it.

The new section covers:
- **Location** — workflow YAMLs go under `inst/workflow/` (singular, canonical; plural tolerated per [workr#45](https://github.com/Gilead-BioStats/workr/issues/45)).
- **Numbered-folder convention** — `0_other`, `1_mappings`, `2_metrics`, `3_reporting`, `4_modules`, including which folders are non-runnable phases.
- **Naming rules** — one workflow per file, `meta:` requirements, and fully-qualified (namespaced) step functions.
- **Collision policy** — filenames must be unique across the ecosystem within a phase; warns/fails per [workr#46](https://github.com/Gilead-BioStats/workr/issues/46).
- **Private-package considerations** — runtime access requirements for private-package workflows.

Also adds a pointer to the section from `README.md` and a `NEWS.md` entry.

## Test Notes/Sample Code

Documentation-only change (Markdown). No code or tests affected. The conventions documented were verified against the actual `inst/workflow/` layouts in `gsm.mapping`, `gsm.kri`, and `gsm.reporting`, and against the gaps surfaced running the bundle end-to-end in the `AA-AA-000-0000` study repo.

Follow-up (per the issue, after merge): link to this section from `gismo.library/README.md` and downstream ecosystem repos' CONTRIBUTING files.

## Connected Issues

- Closes #145