### PR TITLE
fix: update Gilead-BioStats links to Gilead-Public

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Issues are the primary way to communicate what needs to be done and to track pro
 
 
 
-The issue templates automatically appear when you select `New Issue` to create a new issue in a given repository, are maintained in {[gsm.utils](https://github.com/Gilead-BioStats/gsm.utils)} and automatically updated in all gsm packages whenever updates are made. Note that suggestions or other input that might not warrant formal submission of an issue can be filed in the Github `Discussions` tab for that repository, which can help facilitate discourse of specific use-cases or requests.
+The issue templates automatically appear when you select `New Issue` to create a new issue in a given repository, are maintained in {[gsm.utils](https://github.com/Gilead-Public/gsm.utils)} and automatically updated in all gsm packages whenever updates are made. Note that suggestions or other input that might not warrant formal submission of an issue can be filed in the Github `Discussions` tab for that repository, which can help facilitate discourse of specific use-cases or requests.
 
 ---
 
@@ -157,7 +157,7 @@ GitHub Actions run automatically on Pull Requests and other repository events to
 
 ### Workflow Configuration
 
-Most workflows are generated and maintained through [`gsm.utils`](https://github.com/Gilead-BioStats/gsm.utils) to ensure consistency across all GSM packages. The one exception to this is `qcthat.yaml` which is maintained in the [`qcthat`](https://github.com/Gilead-BioStats/qcthat) package. Key features:
+Most workflows are generated and maintained through [`gsm.utils`](https://github.com/Gilead-Public/gsm.utils) to ensure consistency across all GSM packages. The one exception to this is `qcthat.yaml` which is maintained in the [`qcthat`](https://github.com/Gilead-Public/qcthat) package. Key features:
 
 - **Automatic triggers**: Workflows run on relevant events (PRs, pushes, releases)
 - **Multi-platform support**: Testing across Linux, macOS, and Windows

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -8,7 +8,7 @@
 ## Milestone
 <!--- Link to the milestone for the release. ---> 
 <!--- Make sure all relevant issues/PRs are included on the linked pages. --->
-Milestone: [v1.0.0](https://github.com/Gilead-BioStats/gsm.core/milestone/1)
+Milestone: [v1.0.0](https://github.com/Gilead-Public/gsm.core/milestone/1)
 
 # Overall Risk Assessment 
 <!--- Complete the following Risk Assessment for this Release-->
@@ -45,6 +45,6 @@ Notes:
 - [ ] Formatted code with `styler`
 - [ ] Run `spell_check()`
 - [ ] Completed QC of documentation including `README.md` and relevant Vignettes
-- [ ] Build site `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new functions occur on the "[Reference](https://gilead-biostats.github.io/gsm.core/reference/index.html)" page. 
+- [ ] Build site `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new functions occur on the "[Reference](https://gilead-public.github.io/gsm.core/reference/index.html)" page. 
 - [ ] Draft GitHub release created using automatic template and updated with additional details. Remember to click "release" after PR is merged.  
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,9 +31,9 @@ Description: The Good Statistical Monitoring or 'gsm' suite of R packages
     workflow execution utilities are provided by the companion package
     'workr'.
 License: Apache License (>= 2)
-URL: https://gilead-biostats.github.io/gsm.core,
-    https://github.com/Gilead-BioStats/gsm.core,
-BugReports: https://github.com/Gilead-BioStats/gsm.core/issues
+URL: https://gilead-public.github.io/gsm.core,
+    https://github.com/Gilead-Public/gsm.core,
+BugReports: https://github.com/Gilead-Public/gsm.core/issues
 Depends: 
     R (>= 4.0)
 Imports:
@@ -68,7 +68,7 @@ Suggests:
     usethis,
     withr
 Remotes:
-    workr=Gilead-BioStats/workr@main
+    workr=Gilead-Public/workr@main
 VignetteBuilder: 
     knitr
 Config/Needs/website: DT, here, pkgdown, devtools

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -40,37 +40,27 @@ export(cli_fmt)
 export(stop_if)
 import(dplyr)
 import(purrr)
-importFrom(cli,
-  cli_abort,
-  cli_alert,
-  cli_alert_info,
-  cli_alert_success,
-  cli_h1,
-  cli_h2,
-  cli_inform,
-  cli_text,
-  cli_warn
-)
-importFrom(glue,
-  glue,
-  glue_collapse
-)
+importFrom(cli,cli_abort)
+importFrom(cli,cli_alert)
+importFrom(cli,cli_alert_info)
+importFrom(cli,cli_alert_success)
+importFrom(cli,cli_h1)
+importFrom(cli,cli_h2)
+importFrom(cli,cli_inform)
+importFrom(cli,cli_text)
+importFrom(cli,cli_warn)
+importFrom(glue,glue)
+importFrom(glue,glue_collapse)
 importFrom(lifecycle,deprecated)
 importFrom(magrittr,"%>%")
-importFrom(rlang,
-  "%||%",
-  .data,
-  check_installed
-)
-importFrom(stats,
-  fisher.test,
-  glm,
-  offset,
-  poisson,
-  setNames
-)
-importFrom(tidyr,
-  expand_grid,
-  unnest
-)
+importFrom(rlang,"%||%")
+importFrom(rlang,.data)
+importFrom(rlang,check_installed)
+importFrom(stats,fisher.test)
+importFrom(stats,glm)
+importFrom(stats,offset)
+importFrom(stats,poisson)
+importFrom(stats,setNames)
+importFrom(tidyr,expand_grid)
+importFrom(tidyr,unnest)
 importFrom(yaml,read_yaml)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -40,27 +40,37 @@ export(cli_fmt)
 export(stop_if)
 import(dplyr)
 import(purrr)
-importFrom(cli,cli_abort)
-importFrom(cli,cli_alert)
-importFrom(cli,cli_alert_info)
-importFrom(cli,cli_alert_success)
-importFrom(cli,cli_h1)
-importFrom(cli,cli_h2)
-importFrom(cli,cli_inform)
-importFrom(cli,cli_text)
-importFrom(cli,cli_warn)
-importFrom(glue,glue)
-importFrom(glue,glue_collapse)
+importFrom(cli,
+  cli_abort,
+  cli_alert,
+  cli_alert_info,
+  cli_alert_success,
+  cli_h1,
+  cli_h2,
+  cli_inform,
+  cli_text,
+  cli_warn
+)
+importFrom(glue,
+  glue,
+  glue_collapse
+)
 importFrom(lifecycle,deprecated)
 importFrom(magrittr,"%>%")
-importFrom(rlang,"%||%")
-importFrom(rlang,.data)
-importFrom(rlang,check_installed)
-importFrom(stats,fisher.test)
-importFrom(stats,glm)
-importFrom(stats,offset)
-importFrom(stats,poisson)
-importFrom(stats,setNames)
-importFrom(tidyr,expand_grid)
-importFrom(tidyr,unnest)
+importFrom(rlang,
+  "%||%",
+  .data,
+  check_installed
+)
+importFrom(stats,
+  fisher.test,
+  glm,
+  offset,
+  poisson,
+  setNames
+)
+importFrom(tidyr,
+  expand_grid,
+  unnest
+)
 importFrom(yaml,read_yaml)

--- a/R/Analyze_Fisher.R
+++ b/R/Analyze_Fisher.R
@@ -5,7 +5,7 @@
 #'   Analyzes count data using the Fisher's exact test.
 #'
 #'   More information can be found in [The Fisher's Exact Method
-#'   Section](https://gilead-biostats.github.io/gsm.core/articles/KRI%20Method.html#the-fishers-exact-method)
+#'   Section](https://gilead-public.github.io/gsm.core/articles/KRI%20Method.html#the-fishers-exact-method)
 #'   of the KRI Method vignette.
 #'
 #' @section Statistical Methods:
@@ -25,7 +25,7 @@
 #' @param dfTransformed `data.frame` Transformed data for analysis. Data should
 #'   have one record per site with expected columns: `GroupID`, `GroupLevel`,
 #'   `Numerator`, `Denominator`, and `Metric`. For more details see the
-#'   [Data Model article](https://gilead-biostats.github.io/gsm.core/articles/DataModel.html).
+#'   [Data Model article](https://gilead-public.github.io/gsm.core/articles/DataModel.html).
 #'   For this function, `dfTransformed` should typically be created using
 #'   [Transform_Rate()].
 #' @param strOutcome `character` required, name of column in `dfTransformed`

--- a/R/Analyze_Identity.R
+++ b/R/Analyze_Identity.R
@@ -6,13 +6,13 @@
 #'   Score columns.
 #'
 #'   More information can be found in [The Identity
-#'   Method](https://gilead-biostats.github.io/gsm.core/articles/KRI%20Method.html#the-identity-method)
+#'   Method](https://gilead-public.github.io/gsm.core/articles/KRI%20Method.html#the-identity-method)
 #'   of the KRI Method vignette.
 #'
 #' @param dfTransformed `data.frame` Transformed data for analysis. Data should
 #'   have one record per site with expected columns: `GroupID`, `GroupLevel`,
 #'   `Numerator`, `Denominator`, and `Metric`. For more details see the
-#'   [Data Model article](https://gilead-biostats.github.io/gsm.core/articles/DataModel.html).
+#'   [Data Model article](https://gilead-public.github.io/gsm.core/articles/DataModel.html).
 #'   For this function, `dfTransformed` should typically be created using
 #'   [Transform_Count()].
 #' @param strValueCol `character` Name of column that will be copied as `Score`

--- a/R/Analyze_NormalApprox.R
+++ b/R/Analyze_NormalApprox.R
@@ -6,7 +6,7 @@
 #' method with normal approximation.
 #'
 #' More information can be found in [The Normal Approximation
-#' Method](https://gilead-biostats.github.io/gsm.core/articles/KRI%20Method.html#the-normal-approximation-method)
+#' Method](https://gilead-public.github.io/gsm.core/articles/KRI%20Method.html#the-normal-approximation-method)
 #' of the KRI Method vignette.
 #'
 #' @section Statistical Methods: This function applies funnel plots using
@@ -18,7 +18,7 @@
 #' @param dfTransformed `data.frame` Transformed data for analysis. Data should
 #'   have one record per site with expected columns: `GroupID`, `GroupLevel`,
 #'   `Numerator`, `Denominator`, and `Metric`. For more details see the
-#'   [Data Model article](https://gilead-biostats.github.io/gsm.core/articles/DataModel.html).
+#'   [Data Model article](https://gilead-public.github.io/gsm.core/articles/DataModel.html).
 #'   For this function, `dfTransformed` should typically be created using
 #'   [Transform_Rate()].
 #' @param strType `character` Statistical outcome type. Valid values:

--- a/R/Analyze_NormalApprox_PredictBounds.R
+++ b/R/Analyze_NormalApprox_PredictBounds.R
@@ -15,7 +15,7 @@
 #' @param dfTransformed `data.frame` Transformed data for analysis. Data should
 #'   have one record per site with expected columns: `GroupID`, `GroupLevel`,
 #'   `Numerator`, `Denominator`, and `Metric`. For more details see the
-#'   [Data Model article](https://gilead-biostats.github.io/gsm.core/articles/DataModel.html).
+#'   [Data Model article](https://gilead-public.github.io/gsm.core/articles/DataModel.html).
 #'   For this function, `dfTransformed` should typically be created using
 #'   [Transform_Rate()].
 #' @param vThreshold `numeric` upper and lower boundaries based on standard

--- a/R/Analyze_Poisson.R
+++ b/R/Analyze_Poisson.R
@@ -6,7 +6,7 @@
 #' Residual and Predicted Count for each site.
 #'
 #' More information can be found in [The Poisson Regression
-#' Method](https://gilead-biostats.github.io/gsm.core/articles/KRI%20Method.html#the-poisson-regression-method)
+#' Method](https://gilead-public.github.io/gsm.core/articles/KRI%20Method.html#the-poisson-regression-method)
 #' of the KRI Method vignette.
 #'
 #' @section Statistical Methods:
@@ -20,7 +20,7 @@
 #' @param dfTransformed `data.frame` Transformed data for analysis. Data should
 #'   have one record per site with expected columns: `GroupID`, `GroupLevel`,
 #'   `Numerator`, `Denominator`, and `Metric`. For more details see the
-#'   [Data Model article](https://gilead-biostats.github.io/gsm.core/articles/DataModel.html).
+#'   [Data Model article](https://gilead-public.github.io/gsm.core/articles/DataModel.html).
 #'   For this function, `dfTransformed` should typically be created using
 #'   [Transform_Rate()].
 #'

--- a/R/Analyze_Poisson_PredictBounds.R
+++ b/R/Analyze_Poisson_PredictBounds.R
@@ -15,7 +15,7 @@
 #'
 #' @param dfTransformed `data.frame` Transformed data for analysis. Data should
 #'   have one record per site with expected columns: `GroupID`, `GroupLevel`,
-#'   `Numerator`, `Denominator`, and `Metric`. For more details see the [Data Model article](https://gilead-biostats.github.io/gsm.core/articles/DataModel.html).
+#'   `Numerator`, `Denominator`, and `Metric`. For more details see the [Data Model article](https://gilead-public.github.io/gsm.core/articles/DataModel.html).
 #'   For this
 #'   function, `dfTransformed` should typically be created using
 #'   [Transform_Rate()].

--- a/R/Flag.R
+++ b/R/Flag.R
@@ -8,7 +8,7 @@
 #'
 #' @details
 #' This function provides a generalized framework for flagging sites as part of the
-#' gsm data model (see the [Data Model article](https://gilead-biostats.github.io/gsm.core/articles/DataModel.html)).
+#' gsm data model (see the [Data Model article](https://gilead-public.github.io/gsm.core/articles/DataModel.html)).
 #'
 #' @section Data Specification:
 #' \code{Flag} is designed to support the input data (`dfAnalyzed`) from the `Analyze_Identity()`

--- a/R/RunStep.R
+++ b/R/RunStep.R
@@ -10,7 +10,7 @@
 #'   include the name of the function to run (`lStep$name`), name of the object where the function result should be saved (`lStep$output`) and configurable parameters (`lStep$params`) (if any)
 #' @param lData `list` a named list of domain level data frames.
 #' @param lSpec `list` a data specification containing required columns. See the
-#'  [gsm Extensions article](https://gilead-biostats.github.io/gsm.core/articles/gsmExtensions.html).
+#'  [gsm Extensions article](https://gilead-public.github.io/gsm.core/articles/gsmExtensions.html).
 #' @param lMeta `list` a named list of meta data.
 #'
 #' @examples

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 <div class="pkgdown-release">
 
-[![R-CMD-check](https://github.com/Gilead-BioStats/gsm.core/actions/workflows/R-CMD-check.yaml/badge.svg?branch=main)](https://github.com/Gilead-BioStats/gsm.core/actions/workflows/R-CMD-check.yaml)
-[![test-coverage](https://github.com/Gilead-BioStats/gsm.core/actions/workflows/test-coverage.yaml/badge.svg?branch=main)](https://github.com/Gilead-BioStats/gsm.core/actions/workflows/test-coverage.yaml)
-[![pkgdown-all](https://github.com/Gilead-BioStats/gsm.core/actions/workflows/pkgdown-all.yaml/badge.svg?branch=main)](https://github.com/Gilead-BioStats/gsm.core/actions/workflows/pkgdown-all.yaml)
+[![R-CMD-check](https://github.com/Gilead-Public/gsm.core/actions/workflows/R-CMD-check.yaml/badge.svg?branch=main)](https://github.com/Gilead-Public/gsm.core/actions/workflows/R-CMD-check.yaml)
+[![test-coverage](https://github.com/Gilead-Public/gsm.core/actions/workflows/test-coverage.yaml/badge.svg?branch=main)](https://github.com/Gilead-Public/gsm.core/actions/workflows/test-coverage.yaml)
+[![pkgdown-all](https://github.com/Gilead-Public/gsm.core/actions/workflows/pkgdown-all.yaml/badge.svg?branch=main)](https://github.com/Gilead-Public/gsm.core/actions/workflows/pkgdown-all.yaml)
 
 </div>
 
 <div class="pkgdown-devel">
 
-[![R-CMD-check](https://github.com/Gilead-BioStats/gsm.core/actions/workflows/R-CMD-check.yaml/badge.svg?branch=dev)](https://github.com/Gilead-BioStats/gsm.core/actions/workflows/R-CMD-check.yaml)
-[![test-coverage](https://github.com/Gilead-BioStats/gsm.core/actions/workflows/test-coverage.yaml/badge.svg?branch=dev)](https://github.com/Gilead-BioStats/gsm.core/actions/workflows/test-coverage.yaml)
-[![pkgdown-all](https://github.com/Gilead-BioStats/gsm.core/actions/workflows/pkgdown-all.yaml/badge.svg?branch=dev)](https://github.com/Gilead-BioStats/gsm.core/actions/workflows/pkgdown-all.yaml)
+[![R-CMD-check](https://github.com/Gilead-Public/gsm.core/actions/workflows/R-CMD-check.yaml/badge.svg?branch=dev)](https://github.com/Gilead-Public/gsm.core/actions/workflows/R-CMD-check.yaml)
+[![test-coverage](https://github.com/Gilead-Public/gsm.core/actions/workflows/test-coverage.yaml/badge.svg?branch=dev)](https://github.com/Gilead-Public/gsm.core/actions/workflows/test-coverage.yaml)
+[![pkgdown-all](https://github.com/Gilead-Public/gsm.core/actions/workflows/pkgdown-all.yaml/badge.svg?branch=dev)](https://github.com/Gilead-Public/gsm.core/actions/workflows/pkgdown-all.yaml)
 
 </div>
 
@@ -24,15 +24,15 @@ The `{gsm.core}` package provides the analytical foundation for a standardized R
 
 <center>![](man/figures/gsm_report_screenshot_1.png)</center>
 
-This README provides a high-level overview of `{gsm.core}`; see the [package website](https://gilead-biostats.github.io/gsm.core/) for additional details.
+This README provides a high-level overview of `{gsm.core}`; see the [package website](https://gilead-public.github.io/gsm.core/) for additional details.
 
-The `{gsm.core}` package is a successor package to [`{gsm}`](https://github.com/Gilead-BioStats/gsm), which has been deprecated as of March 2025. The contents of `{gsm}` have been split out among 4 packages as follows:
+The `{gsm.core}` package is a successor package to [`{gsm}`](https://github.com/Gilead-Public/gsm), which has been deprecated as of March 2025. The contents of `{gsm}` have been split out among 4 packages as follows:
 
 1.  **`{gsm.core}`**: A package containing the analytics functionality used to construct and evaluate metrics.
-2.  [**`{workr}`**](https://github.com/Gilead-BioStats/workr): A package that provides the workflow runtime used to execute YAML-defined steps and workflows.
-3.  [**`{gsm.mapping}`**](https://github.com/Gilead-BioStats/gsm.mapping): A package that provides workflows to apply the necessary data transformation from raw/source datasets to appropriate domains.
-4.  [**`{gsm.kri}`**](https://github.com/Gilead-BioStats/gsm.kri): A package that provides workflows to generate metrics and functionality to visualize and report on these metrics.
-5.  [**`{gsm.reporting}`**](https://github.com/Gilead-BioStats/gsm.reporting): A package that provides workflows to generate the reporting data model needed to generate reports.
+2.  [**`{workr}`**](https://github.com/Gilead-Public/workr): A package that provides the workflow runtime used to execute YAML-defined steps and workflows.
+3.  [**`{gsm.mapping}`**](https://github.com/Gilead-Public/gsm.mapping): A package that provides workflows to apply the necessary data transformation from raw/source datasets to appropriate domains.
+4.  [**`{gsm.kri}`**](https://github.com/Gilead-Public/gsm.kri): A package that provides workflows to generate metrics and functionality to visualize and report on these metrics.
+5.  [**`{gsm.reporting}`**](https://github.com/Gilead-Public/gsm.reporting): A package that provides workflows to generate the reporting data model needed to generate reports.
 
 ## Installation
 
@@ -40,7 +40,7 @@ You can install the latest release of gsm.core from [GitHub](https://github.com/
 
 ``` r
 # install.packages("pak")
-pak::pak("Gilead-BioStats/gsm.core@*release")
+pak::pak("Gilead-Public/gsm.core@*release")
 ```
 
 <div class="pkgdown-devel">
@@ -50,7 +50,7 @@ You can install the development version of gsm.core from
 
 ``` r
 # install.packages("pak")
-pak::pak("Gilead-BioStats/gsm.core")
+pak::pak("Gilead-Public/gsm.core")
 ```
 
 </div>
@@ -93,7 +93,7 @@ All `{gsm.core}` assessments use a standardized 6 step data pipeline:
 5.  **Flag** - Uses `analyzed` data and numeric `thresholds` to create `flagged` data.
 6.  **Summarize** - Selects key columns from `flagged` data to create `summary` data.
 
-To learn more about `{gsm.core}`'s data pipeline, visit the [Data Pipeline article](https://gilead-biostats.github.io/gsm.core/articles/DataModel.html).
+To learn more about `{gsm.core}`'s data pipeline, visit the [Data Pipeline article](https://gilead-public.github.io/gsm.core/articles/DataModel.html).
 
 # Reporting
 
@@ -103,8 +103,8 @@ Detailed RMarkdown/HTML reporting is built into `{gsm.core}`, and provides a det
 
 Full reports for a sample trial run with [`{clindata}`](https://github.com/Gilead-BioStats/clindata) are provided below:
 
--   [Site Report](https://gilead-biostats.github.io/gsm.kri/examples/Example_SiteReport.html)
--   [Country Report](https://gilead-biostats.github.io/gsm.kri/examples/Example_CountryReport.html)
+-   [Site Report](https://gilead-public.github.io/gsm.kri/examples/Example_SiteReport.html)
+-   [Country Report](https://gilead-public.github.io/gsm.kri/examples/Example_CountryReport.html)
 
 # Getting Started
 
@@ -114,32 +114,32 @@ Interested in using {gsm}? Key resources are provided in response to the FAQs be
 
 See the "Process Overview" section above and then check out these articles:
 
--   [Step-by-Step Analysis Workflow Vignette](https://gilead-biostats.github.io/gsm.core/articles/DataAnalysis.html) walks users the step-by-step process for creating metrics (KRIs, QTLs, etc) in {gsm}.
--   [Adverse Event KRI Cookbook Example](https://gilead-biostats.github.io/gsm.kri/dev/examples/Cookbook_AdverseEventKRI.html) provides hands-on examples of how to customize KRI metrics related to Adverse events.
+-   [Step-by-Step Analysis Workflow Vignette](https://gilead-public.github.io/gsm.core/articles/DataAnalysis.html) walks users the step-by-step process for creating metrics (KRIs, QTLs, etc) in {gsm}.
+-   [Adverse Event KRI Cookbook Example](https://gilead-public.github.io/gsm.kri/dev/examples/Cookbook_AdverseEventKRI.html) provides hands-on examples of how to customize KRI metrics related to Adverse events.
 
 ## How do I evaluate a study?
 
 The {gsm} workflow process allows creation of reusable pipelines for study (or even cross-study) data snapshots including data mapping, calculation of multiple metrics and creation of reports. Runtime execution is provided by `{workr}`, while `{gsm.core}` provides the analytical functions used inside those workflows. See the articles below for details and examples.
 
--   [Data Model Vignette](https://gilead-biostats.github.io/gsm.core/articles/DataModel.html) explains the data pipeline used to calculate multiple metrics and generate study-level reports.
--   [Adverse Event Workflow Example](https://gilead-biostats.github.io/gsm.kri/dev/examples/Cookbook_AdverseEventWorkflow.html) demonstrates how to create a configurable workflow using YAML to define the analysis pipeline.
--   [Reporting Workflow Example](https://gilead-biostats.github.io/gsm.kri/dev/examples/Cookbook_ReportingWorkflow.html) demonstrates a complete workflow from raw data to KRI reports using standard metrics.
+-   [Data Model Vignette](https://gilead-public.github.io/gsm.core/articles/DataModel.html) explains the data pipeline used to calculate multiple metrics and generate study-level reports.
+-   [Adverse Event Workflow Example](https://gilead-public.github.io/gsm.kri/dev/examples/Cookbook_AdverseEventWorkflow.html) demonstrates how to create a configurable workflow using YAML to define the analysis pipeline.
+-   [Reporting Workflow Example](https://gilead-public.github.io/gsm.kri/dev/examples/Cookbook_ReportingWorkflow.html) demonstrates a complete workflow from raw data to KRI reports using standard metrics.
 
 ## How do I customize my study?
 
 The {gsm} framework is designed to be highly modular and customizable. The sections above show examples of customized metrics and workflows. It's also straightforward to add entire custom modules that add new mappings, metrics and reports. See the vignette below for details.
 
--   [gsm Extensions Vignette](https://gilead-biostats.github.io/gsm.core/articles/gsmExtensions.html) describes how to extend {gsm.core} by creating new ‘modules’, including metrics, reports and shiny apps that can be run using the standard gsm pipeline.
+-   [gsm Extensions Vignette](https://gilead-public.github.io/gsm.core/articles/gsmExtensions.html) describes how to extend {gsm.core} by creating new ‘modules’, including metrics, reports and shiny apps that can be run using the standard gsm pipeline.
 
 ## What reports are available for my study?
 
 Here are links to sample reports that are available in the {gsm} family of packages. We're working on adding more all the time and will continue adding examples to this list as they are released.
 
--   [Site KRI Report](https://gilead-biostats.github.io/gsm.kri/examples/Example_SiteReport.html)
--   [Country KRI Report](https://gilead-biostats.github.io/gsm.kri/examples/Example_CountryReport.html)
--   [Eligibility Report](https://gilead-biostats.github.io/gsm.kri/dev/examples/Example_Eligibility.html)
--   [Cross-Study Site Risk Score Report](https://gilead-biostats.github.io/gsm.kri/dev/examples/Example_CrossStudySRS.html)
--   [QTL Report](https://gilead-biostats.github.io/gsm.qtl/examples/Example_QTL.html)
+-   [Site KRI Report](https://gilead-public.github.io/gsm.kri/examples/Example_SiteReport.html)
+-   [Country KRI Report](https://gilead-public.github.io/gsm.kri/examples/Example_CountryReport.html)
+-   [Eligibility Report](https://gilead-public.github.io/gsm.kri/dev/examples/Example_Eligibility.html)
+-   [Cross-Study Site Risk Score Report](https://gilead-public.github.io/gsm.kri/dev/examples/Example_CrossStudySRS.html)
+-   [QTL Report](https://gilead-public.github.io/gsm.qtl/examples/Example_QTL.html)
 -   [Good Statistical Monitoring Shiny App](https://rinpharma.shinyapps.io/gsm-app/)
 
 # Quality Control
@@ -162,12 +162,12 @@ Since {gsm.core} is designed for use in a [GCP](https://en.wikipedia.org/wiki/Go
 ## Development Practices
 
 -   **Code Review** - All changes reviewed and approved via GitHub Pull Requests by QC programmers.
--   **Continuous Integration** - Automated workflows via GitHub Actions. Full list of GitHub Actions utilized can be found in the [GitHub Actions Workflows](https://gilead-biostats.github.io/gsm.utils/index.html#github-actions-workflows) section of the `{gsm.utils}` package.
+-   **Continuous Integration** - Automated workflows via GitHub Actions. Full list of GitHub Actions utilized can be found in the [GitHub Actions Workflows](https://gilead-public.github.io/gsm.utils/index.html#github-actions-workflows) section of the `{gsm.utils}` package.
 -   **Package Checks** - Standard R package checks must pass before PRs are merged.
 
 ## Qualification Framework
 
-{gsm.core} utilizes [`{qcthat}`](https://gilead-biostats.github.io/qcthat/index.html) package that provides a structured qualification process by:
+{gsm.core} utilizes [`{qcthat}`](https://gilead-public.github.io/qcthat/index.html) package that provides a structured qualification process by:
 
 -   Linking package requirements (documented as GitHub issues) to qualification and unit tests
 -   Generating automated qualification reports showing requirement coverage and test results for every PR and release.
@@ -176,5 +176,5 @@ Since {gsm.core} is designed for use in a [GCP](https://en.wikipedia.org/wiki/Go
 
 This comprehensive approach ensures all requirements are properly tested and verified before each release.
 
-Additional detail, including links to functional documentation and vignettes, is available in the [package website](https://gilead-biostats.github.io/gsm.core/).
+Additional detail, including links to functional documentation and vignettes, is available in the [package website](https://gilead-public.github.io/gsm.core/).
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://gilead-biostats.github.io/gsm.core
+url: https://gilead-public.github.io/gsm.core
 
 template:
   bootstrap: 5

--- a/data-raw/simulate_longitudinal_data.R
+++ b/data-raw/simulate_longitudinal_data.R
@@ -1,7 +1,7 @@
-pak::pak('Gilead-BioStats/gsm.datasim@dev')
-pak::pak('Gilead-BioStats/gsm.mapping@dev')
-pak::pak('Gilead-BioStats/gsm.core@dev')
-pak::pak('Gilead-BioStats/gsm.kri@dev')
+pak::pak('Gilead-Public/gsm.datasim@dev')
+pak::pak('Gilead-Public/gsm.mapping@dev')
+pak::pak('Gilead-Public/gsm.core@dev')
+pak::pak('Gilead-Public/gsm.kri@dev')
 
 library(gsm.core)
 library(gsm.mapping)

--- a/man/Analyze_Fisher.Rd
+++ b/man/Analyze_Fisher.Rd
@@ -10,7 +10,7 @@ Analyze_Fisher(dfTransformed, strOutcome = "Numerator")
 \item{dfTransformed}{\code{data.frame} Transformed data for analysis. Data should
 have one record per site with expected columns: \code{GroupID}, \code{GroupLevel},
 \code{Numerator}, \code{Denominator}, and \code{Metric}. For more details see the
-\href{https://gilead-biostats.github.io/gsm.core/articles/DataModel.html}{Data Model article}.
+\href{https://gilead-public.github.io/gsm.core/articles/DataModel.html}{Data Model article}.
 For this function, \code{dfTransformed} should typically be created using
 \code{\link[=Transform_Rate]{Transform_Rate()}}.}
 
@@ -27,7 +27,7 @@ Estimate, and Score.
 
 Analyzes count data using the Fisher's exact test.
 
-More information can be found in \href{https://gilead-biostats.github.io/gsm.core/articles/KRI\%20Method.html#the-fishers-exact-method}{The Fisher's Exact Method Section}
+More information can be found in \href{https://gilead-public.github.io/gsm.core/articles/KRI\%20Method.html#the-fishers-exact-method}{The Fisher's Exact Method Section}
 of the KRI Method vignette.
 }
 \section{Statistical Methods}{

--- a/man/Analyze_Identity.Rd
+++ b/man/Analyze_Identity.Rd
@@ -10,7 +10,7 @@ Analyze_Identity(dfTransformed, strValueCol = "Metric")
 \item{dfTransformed}{\code{data.frame} Transformed data for analysis. Data should
 have one record per site with expected columns: \code{GroupID}, \code{GroupLevel},
 \code{Numerator}, \code{Denominator}, and \code{Metric}. For more details see the
-\href{https://gilead-biostats.github.io/gsm.core/articles/DataModel.html}{Data Model article}.
+\href{https://gilead-public.github.io/gsm.core/articles/DataModel.html}{Data Model article}.
 For this function, \code{dfTransformed} should typically be created using
 \code{\link[=Transform_Count]{Transform_Count()}}.}
 
@@ -26,7 +26,7 @@ Metric, and Score.
 Used in the data pipeline between \code{Transform} and \code{Flag} to rename KRI and
 Score columns.
 
-More information can be found in \href{https://gilead-biostats.github.io/gsm.core/articles/KRI\%20Method.html#the-identity-method}{The Identity Method}
+More information can be found in \href{https://gilead-public.github.io/gsm.core/articles/KRI\%20Method.html#the-identity-method}{The Identity Method}
 of the KRI Method vignette.
 }
 \examples{

--- a/man/Analyze_NormalApprox.Rd
+++ b/man/Analyze_NormalApprox.Rd
@@ -10,7 +10,7 @@ Analyze_NormalApprox(dfTransformed, strType = "binary")
 \item{dfTransformed}{\code{data.frame} Transformed data for analysis. Data should
 have one record per site with expected columns: \code{GroupID}, \code{GroupLevel},
 \code{Numerator}, \code{Denominator}, and \code{Metric}. For more details see the
-\href{https://gilead-biostats.github.io/gsm.core/articles/DataModel.html}{Data Model article}.
+\href{https://gilead-public.github.io/gsm.core/articles/DataModel.html}{Data Model article}.
 For this function, \code{dfTransformed} should typically be created using
 \code{\link[=Transform_Rate]{Transform_Rate()}}.}
 
@@ -30,7 +30,7 @@ Denominator, Metric, OverallMetric, Factor, and Score.
 Creates analysis results data for percentage/rate data using funnel plot
 method with normal approximation.
 
-More information can be found in \href{https://gilead-biostats.github.io/gsm.core/articles/KRI\%20Method.html#the-normal-approximation-method}{The Normal Approximation Method}
+More information can be found in \href{https://gilead-public.github.io/gsm.core/articles/KRI\%20Method.html#the-normal-approximation-method}{The Normal Approximation Method}
 of the KRI Method vignette.
 }
 \section{Statistical Methods}{

--- a/man/Analyze_NormalApprox_PredictBounds.Rd
+++ b/man/Analyze_NormalApprox_PredictBounds.Rd
@@ -15,7 +15,7 @@ Analyze_NormalApprox_PredictBounds(
 \item{dfTransformed}{\code{data.frame} Transformed data for analysis. Data should
 have one record per site with expected columns: \code{GroupID}, \code{GroupLevel},
 \code{Numerator}, \code{Denominator}, and \code{Metric}. For more details see the
-\href{https://gilead-biostats.github.io/gsm.core/articles/DataModel.html}{Data Model article}.
+\href{https://gilead-public.github.io/gsm.core/articles/DataModel.html}{Data Model article}.
 For this function, \code{dfTransformed} should typically be created using
 \code{\link[=Transform_Rate]{Transform_Rate()}}.}
 

--- a/man/Analyze_Poisson.Rd
+++ b/man/Analyze_Poisson.Rd
@@ -10,7 +10,7 @@ Analyze_Poisson(dfTransformed)
 \item{dfTransformed}{\code{data.frame} Transformed data for analysis. Data should
 have one record per site with expected columns: \code{GroupID}, \code{GroupLevel},
 \code{Numerator}, \code{Denominator}, and \code{Metric}. For more details see the
-\href{https://gilead-biostats.github.io/gsm.core/articles/DataModel.html}{Data Model article}.
+\href{https://gilead-public.github.io/gsm.core/articles/DataModel.html}{Data Model article}.
 For this function, \code{dfTransformed} should typically be created using
 \code{\link[=Transform_Rate]{Transform_Rate()}}.}
 }
@@ -25,7 +25,7 @@ Denominator, Metric, Score, and PredictedCount.
 Fits a Poisson model to site-level data and adds columns capturing
 Residual and Predicted Count for each site.
 
-More information can be found in \href{https://gilead-biostats.github.io/gsm.core/articles/KRI\%20Method.html#the-poisson-regression-method}{The Poisson Regression Method}
+More information can be found in \href{https://gilead-public.github.io/gsm.core/articles/KRI\%20Method.html#the-poisson-regression-method}{The Poisson Regression Method}
 of the KRI Method vignette.
 }
 \section{Statistical Methods}{

--- a/man/Analyze_Poisson_PredictBounds.Rd
+++ b/man/Analyze_Poisson_PredictBounds.Rd
@@ -13,7 +13,7 @@ Analyze_Poisson_PredictBounds(
 \arguments{
 \item{dfTransformed}{\code{data.frame} Transformed data for analysis. Data should
 have one record per site with expected columns: \code{GroupID}, \code{GroupLevel},
-\code{Numerator}, \code{Denominator}, and \code{Metric}. For more details see the \href{https://gilead-biostats.github.io/gsm.core/articles/DataModel.html}{Data Model article}.
+\code{Numerator}, \code{Denominator}, and \code{Metric}. For more details see the \href{https://gilead-public.github.io/gsm.core/articles/DataModel.html}{Data Model article}.
 For this
 function, \code{dfTransformed} should typically be created using
 \code{\link[=Transform_Rate]{Transform_Rate()}}.}

--- a/man/Flag.Rd
+++ b/man/Flag.Rd
@@ -43,7 +43,7 @@ method is used.
 }
 \details{
 This function provides a generalized framework for flagging sites as part of the
-gsm data model (see the \href{https://gilead-biostats.github.io/gsm.core/articles/DataModel.html}{Data Model article}).
+gsm data model (see the \href{https://gilead-public.github.io/gsm.core/articles/DataModel.html}{Data Model article}).
 }
 \section{Data Specification}{
 

--- a/man/RunStep.Rd
+++ b/man/RunStep.Rd
@@ -15,7 +15,7 @@ include the name of the function to run (\code{lStep$name}), name of the object 
 \item{lMeta}{\code{list} a named list of meta data.}
 
 \item{lSpec}{\code{list} a data specification containing required columns. See the
-\href{https://gilead-biostats.github.io/gsm.core/articles/gsmExtensions.html}{gsm Extensions article}.}
+\href{https://gilead-public.github.io/gsm.core/articles/gsmExtensions.html}{gsm Extensions article}.}
 }
 \value{
 \code{list} containing the results of the \code{lStep$name} function call should contain \code{.$checks}

--- a/man/gsm.core-package.Rd
+++ b/man/gsm.core-package.Rd
@@ -11,9 +11,9 @@ The Good Statistical Monitoring or 'gsm' suite of R packages provides a framewor
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://gilead-biostats.github.io/gsm.core}
-  \item \url{https://github.com/Gilead-BioStats/gsm.core},
-  \item Report bugs at \url{https://github.com/Gilead-BioStats/gsm.core/issues}
+  \item \url{https://gilead-public.github.io/gsm.core}
+  \item \url{https://github.com/Gilead-Public/gsm.core,}
+  \item Report bugs at \url{https://github.com/Gilead-Public/gsm.core/issues}
 }
 
 }
@@ -22,7 +22,6 @@ Useful links:
 
 Authors:
 \itemize{
-  \item Jeremy Wildfire \email{jwildfire@gmail.com}
   \item George Wu \email{george.wu@gilead.com}
   \item Spencer Childress \email{spencer.childress@gilead.com} (\href{https://orcid.org/0000-0001-6877-8511}{ORCID})
   \item Laura Maxwell \email{laura.maxwell@atorusresearch.com}

--- a/man/gsm.core-package.Rd
+++ b/man/gsm.core-package.Rd
@@ -12,7 +12,7 @@ The Good Statistical Monitoring or 'gsm' suite of R packages provides a framewor
 Useful links:
 \itemize{
   \item \url{https://gilead-public.github.io/gsm.core}
-  \item \url{https://github.com/Gilead-Public/gsm.core,}
+  \item \url{https://github.com/Gilead-Public/gsm.core},
   \item Report bugs at \url{https://github.com/Gilead-Public/gsm.core/issues}
 }
 
@@ -22,6 +22,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Jeremy Wildfire \email{jwildfire@gmail.com}
   \item George Wu \email{george.wu@gilead.com}
   \item Spencer Childress \email{spencer.childress@gilead.com} (\href{https://orcid.org/0000-0001-6877-8511}{ORCID})
   \item Laura Maxwell \email{laura.maxwell@atorusresearch.com}

--- a/man/reportingBounds_study.Rd
+++ b/man/reportingBounds_study.Rd
@@ -5,7 +5,7 @@
 \alias{reportingBounds_study}
 \title{reportingBounds_study Dataset}
 \format{
-A data frame with 75 rows and 8 columns:
+A data frame with 90 rows and 8 columns:
 \describe{
 \item{Threshold}{number of standard deviations that the upper and lower bounds are based on}
 \item{Denominator}{calculated denominator value}

--- a/tests/testthat/helper-cached-workflows.R
+++ b/tests/testthat/helper-cached-workflows.R
@@ -299,8 +299,8 @@ get_cached_workflows <- function(
 
   # Repository mapping
   repo_map <- list(
-    "gsm.kri" = "Gilead-BioStats/gsm.kri",
-    "gsm.mapping" = "Gilead-BioStats/gsm.mapping"
+    "gsm.kri" = "Gilead-Public/gsm.kri",
+    "gsm.mapping" = "Gilead-Public/gsm.mapping"
   )
 
   repo <- repo_map[[strPackage]]

--- a/vignettes/KRIMethod.Rmd
+++ b/vignettes/KRIMethod.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 # Overview
 
 This vignette outlines the statistical methods used to evaluate Key Risk Indicators (KRIs) in the {gsm} suite of packages. KRIs are metrics that allow users to measure pre-defined risks and determine the level of observed risk to data quality and patient safety in a clinical trial. The {gsm} suite of packages  implements a standardized data pipeline to facilitate KRI analysis. Other vignettes provide an overview of this framework ([1](Cookbook.html) [2](DataModel.html), [3](DataAnalysis.html),
-[4](https://gilead-biostats.github.io/gsm.reporting/articles/DataReporting.html)), and the statistical methods for this process are described in detail below.
+[4](https://gilead-public.github.io/gsm.reporting/articles/DataReporting.html)), and the statistical methods for this process are described in detail below.
 
 `{gsm.core}` calculates KRIs by defining a numerator and a denominator for each metric. Then by default, `{gsm.core}` calculates z-scores using a normal approximation with adjustment for over-dispersion to assign risk levels. 
 

--- a/vignettes/articles/DataAnalysis.Rmd
+++ b/vignettes/articles/DataAnalysis.Rmd
@@ -27,7 +27,7 @@ These functions provide data frames, visualizations, and metadata to be used in 
 
 ![](data_analysis.png){width="100%"} 
 
-All of these functions will run automatically and sequentially when a user calls `workr::RunWorkflow()` with a specified yaml file for KRI metrics found in the `workflow/2_metrics` directory of the [`{gsm.kri}`](https://github.com/Gilead-BioStats/gsm.kri) package.
+All of these functions will run automatically and sequentially when a user calls `workr::RunWorkflow()` with a specified yaml file for KRI metrics found in the `workflow/2_metrics` directory of the [`{gsm.kri}`](https://github.com/Gilead-Public/gsm.kri) package.
 
 Each of these individual functions can also be run independently outside of a specified yaml workflow.
 
@@ -37,7 +37,7 @@ For the purposes of this documentation, we will evaluate the input(s) and output
 
 ## Case Study - Step-by-Step Adverse Event KRI
 
-We will use sample clinical data simulated with the [`{gsm.datasim}`](https://github.com/Gilead-BioStats/gsm.datasim) package to run the Adverse Events (AE) Assessment, i.e., `AE_Assess()`, using the normal approximation method.
+We will use sample clinical data simulated with the [`{gsm.datasim}`](https://github.com/Gilead-Public/gsm.datasim) package to run the Adverse Events (AE) Assessment, i.e., `AE_Assess()`, using the normal approximation method.
 
 Additional statistical methods and supporting functions are explored in [Appendix 1](#appendix-1).
 
@@ -217,7 +217,7 @@ The following sections include various examples of supporting functions and stat
 
 ### What Statistical Models Are Available For Each Assessment?
 
--   By default, all yaml workflow assessments specified in the `inst/workflow/` directory of the `{gsm.kri}` package use the [normal approximation](https://gilead-biostats.github.io/gsm.core/articles/KRI%20Method.html#the-normal-approximation-method) method.
--   Optionally, other statistical methods include: [**Poisson**](https://gilead-biostats.github.io/gsm.core/articles/KRI%20Method.html#the-poisson-regression-method), [**Fisher's Exact**](https://gilead-biostats.github.io/gsm.core/articles/KRI%20Method.html#the-fishers-exact-method), and [**Identity**](https://gilead-biostats.github.io/gsm.core/articles/KRI%20Method.html#the-identity-method).
+-   By default, all yaml workflow assessments specified in the `inst/workflow/` directory of the `{gsm.kri}` package use the [normal approximation](https://gilead-public.github.io/gsm.core/articles/KRI%20Method.html#the-normal-approximation-method) method.
+-   Optionally, other statistical methods include: [**Poisson**](https://gilead-public.github.io/gsm.core/articles/KRI%20Method.html#the-poisson-regression-method), [**Fisher's Exact**](https://gilead-public.github.io/gsm.core/articles/KRI%20Method.html#the-fishers-exact-method), and [**Identity**](https://gilead-public.github.io/gsm.core/articles/KRI%20Method.html#the-identity-method).
 
 ![](data_analysis_combined.png){width="100%"}

--- a/vignettes/articles/DataModel.Rmd
+++ b/vignettes/articles/DataModel.Rmd
@@ -40,7 +40,7 @@ In general, the `{gsm}` suite of packages is designed to be flexible and customi
 
 The `{gsm}` suite of packages is designed to work with a wide variety of clinical data sources. The raw data used in the analysis pipeline is typically sourced from clinical trial databases and is transformed into mapped data using simple transformations. Mapped data is then used as input for the analysis pipeline. 
 
-There is not a single data standard for raw or mapped data in `{gsm.mapping}`. The only requirement is that the mapped data is compatible with the analytics pipeline. Data Mapping transformations can be done using multiple methods including custom R scripts (e.g., with `dplyr`), SQL queries, or using `gsm.mapping` workflows (e.g. the `system.file("workflow/1_mapping/AE.yaml", package = "gsm.mapping")` file). Examples of these methods can be found in the [Cookbook](https://gilead-biostats.github.io/gsm.core/articles/Cookbook.html).
+There is not a single data standard for raw or mapped data in `{gsm.mapping}`. The only requirement is that the mapped data is compatible with the analytics pipeline. Data Mapping transformations can be done using multiple methods including custom R scripts (e.g., with `dplyr`), SQL queries, or using `gsm.mapping` workflows (e.g. the `system.file("workflow/1_mapping/AE.yaml", package = "gsm.mapping")` file). Examples of these methods can be found in the [Cookbook](https://gilead-public.github.io/gsm.core/articles/Cookbook.html).
 
 # Analysis Data 
 
@@ -61,14 +61,14 @@ The data requirements for each component of the analysis pipeline are rigid; See
 ## Analysis Workflows
 Since there are rigid data requirements for each component of the analysis data model, the analysis workflow is largely standardized. There are two main approaches to running the analysis workflow:
 
-1. **Scripted Analysis**: Run each step of the analysis pipeline individually using the functions provided in the `{gsm}` suite of packages. This approach is useful for understanding the data requirements and for debugging. See Example 1 in [Cookbook](https://gilead-biostats.github.io/gsm.core/articles/Cookbook.html) for an example of this approach.
-2. **Workflow Analysis**: Run the analysis pipeline using a YAML workflow file. This approach is useful for running the same analysis on multiple studies or for automating the analysis process. See Example 2 in [Cookbook](https://gilead-biostats.github.io/gsm.core/articles/Cookbook.html) for an example of this approach.
+1. **Scripted Analysis**: Run each step of the analysis pipeline individually using the functions provided in the `{gsm}` suite of packages. This approach is useful for understanding the data requirements and for debugging. See Example 1 in [Cookbook](https://gilead-public.github.io/gsm.core/articles/Cookbook.html) for an example of this approach.
+2. **Workflow Analysis**: Run the analysis pipeline using a YAML workflow file. This approach is useful for running the same analysis on multiple studies or for automating the analysis process. See Example 2 in [Cookbook](https://gilead-public.github.io/gsm.core/articles/Cookbook.html) for an example of this approach.
 
 Note that each step in these workflows can be customized based on the requirements for a specific KRI. The graphic below shows four such workflows.
 
 ![](data_analysis_combined.png){width="100%"}
 
-More details about analysis data pipelines can be found in the [Data Analysis article](https://gilead-biostats.github.io/gsm.core/articles/DataAnalysis.html).
+More details about analysis data pipelines can be found in the [Data Analysis article](https://gilead-public.github.io/gsm.core/articles/DataAnalysis.html).
 
 # Reporting Data 
 

--- a/vignettes/articles/gsmExtensions.Rmd
+++ b/vignettes/articles/gsmExtensions.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 
 # Overview
 
-This article describes how to extend `{gsm.core}` by creating new "modules", including metrics, reports and shiny apps that can be run using the standard `gsm` pipeline described in these articles: [Data Analysis](https://gilead-biostats.github.io/gsm.core/articles/DataAnalysis.html) and  [DataReporting](https://gilead-biostats.github.io/gsm.reporting/articles/DataReporting.html). As shown in the [Data Analysis article](https://gilead-biostats.github.io/gsm.core/articles/DataAnalysis.html), the existing `gsm` data pipeline can be used to capture a monitoring 'snapshot' for a study that includes a variety of "modules" including [metrics](https://github.com/Gilead-BioStats/gsm.mapping/tree/dev/inst/workflow/metrics/kri0001.yaml) and [reports](https://github.com/Gilead-BioStats/gsm.kri/blob/dev/inst/workflow/reports/report_kri_site.yaml). 
+This article describes how to extend `{gsm.core}` by creating new "modules", including metrics, reports and shiny apps that can be run using the standard `gsm` pipeline described in these articles: [Data Analysis](https://gilead-public.github.io/gsm.core/articles/DataAnalysis.html) and  [DataReporting](https://gilead-public.github.io/gsm.reporting/articles/DataReporting.html). As shown in the [Data Analysis article](https://gilead-public.github.io/gsm.core/articles/DataAnalysis.html), the existing `gsm` data pipeline can be used to capture a monitoring 'snapshot' for a study that includes a variety of "modules" including [metrics](https://github.com/Gilead-Public/gsm.mapping/tree/dev/inst/workflow/metrics/kri0001.yaml) and [reports](https://github.com/Gilead-Public/gsm.kri/blob/dev/inst/workflow/reports/report_kri_site.yaml). 
 
 This article provides detailed specifications for creating new modules, a description of the directory structure for the yaml workflows that comprise a module pipeline, and links to resources that can be used to configure study-level gsm pipelines that utilize these extensions.
 
@@ -35,8 +35,8 @@ Detailed specifications for each of these sections are provided below.
 
 Here are links to several sample module configuration files:
 
-- [13 Standard gsm KRIs](https://github.com/Gilead-BioStats/gsm.kri/tree/dev/inst/workflow/2_metrics) (e.g. [Adverse Event KRI Metric](https://github.com/Gilead-BioStats/gsm.kri/tree/dev/inst/workflow/2_metrics/kri0001.yaml))
-- [Site-](https://github.com/Gilead-BioStats/gsm.kri/blob/dev/inst/workflow/4_modules/report_kri_site.yaml) and [Country-level KRI Report](https://github.com/Gilead-BioStats/gsm.kri/blob/dev/inst/workflow/4_modules/report_kri_country.yaml)
+- [13 Standard gsm KRIs](https://github.com/Gilead-Public/gsm.kri/tree/dev/inst/workflow/2_metrics) (e.g. [Adverse Event KRI Metric](https://github.com/Gilead-Public/gsm.kri/tree/dev/inst/workflow/2_metrics/kri0001.yaml))
+- [Site-](https://github.com/Gilead-Public/gsm.kri/blob/dev/inst/workflow/4_modules/report_kri_site.yaml) and [Country-level KRI Report](https://github.com/Gilead-Public/gsm.kri/blob/dev/inst/workflow/4_modules/report_kri_country.yaml)
 
 ## `meta` Specification
 
@@ -98,7 +98,7 @@ A simple `meta` section for a report might look like this:
 
 ## `spec` Specification
 
-The `spec` section of the workflow YAML specifies the data requirements for the workflow, including the data tables that are required and the columns that are needed from each table. The `gsm` data pipeline is designed to be highly customizable, but for the purposes of this article, we will assume usage of the standard `gsm` data model described in the [Data Model article](https://gilead-biostats.github.io/gsm.core/articles/DataModel.html). For this standard use case, modules will pull primarily from the "Mapped" and "Reporting" data layers. 
+The `spec` section of the workflow YAML specifies the data requirements for the workflow, including the data tables that are required and the columns that are needed from each table. The `gsm` data pipeline is designed to be highly customizable, but for the purposes of this article, we will assume usage of the standard `gsm` data model described in the [Data Model article](https://gilead-public.github.io/gsm.core/articles/DataModel.html). For this standard use case, modules will pull primarily from the "Mapped" and "Reporting" data layers. 
 
 The `spec` section of the workflow YAML is formatted as a list of data tables, with each table containing a list of columns. Finally, each column contains the following parameters:
 
@@ -107,7 +107,7 @@ The `spec` section of the workflow YAML is formatted as a list of data tables, w
 
 ### `spec` example: Metric Module
 
-Metric `spec`s are typically pulled from the `mapped` data layer. For example, the `spec` section for the [AE KRI metric](https://github.com/Gilead-BioStats/gsm.kri/tree/dev/inst/workflow/2_metrics/kri0001.yaml) is: 
+Metric `spec`s are typically pulled from the `mapped` data layer. For example, the `spec` section for the [AE KRI metric](https://github.com/Gilead-Public/gsm.kri/tree/dev/inst/workflow/2_metrics/kri0001.yaml) is: 
 
 ```
 spec:
@@ -127,7 +127,7 @@ So, in summary, the AE KRI metric requires two data tables, `Mapped_AE` and `Map
 
 ### `spec` examples: Report Module
 
-Report modules most often pull data from the `Reporting` data layer. For example, the [Site-level KRI report](https://github.com/Gilead-BioStats/gsm.kri/blob/dev/inst/workflow/4_modules/report_kri_site.yaml) has the following `spec`: 
+Report modules most often pull data from the `Reporting` data layer. For example, the [Site-level KRI report](https://github.com/Gilead-Public/gsm.kri/blob/dev/inst/workflow/4_modules/report_kri_site.yaml) has the following `spec`: 
 
 ```
 spec:
@@ -330,13 +330,13 @@ steps:
 
 The metrics directory contains all of the workflows that perform analysis steps, converting mapped data into metrics that are displayed in a report. In the case of `{gsm.kri}`, these metrics are the 12 Key Risk Indicators, calculated at both the site- and country-level, that are discussed in the Data Analysis Step-by-Step article. Each yaml in this file produces a list of analysis data tables that capture the formatted input table, the transformed table, the flagged table, and the summary table. In general, these yamls should at least provide a summary table that contains statistics about the metric at the specified level of aggregation.
 
-Examples of these yamls can be found above in the `Module Configuration` section, as well as in the [Data Analysis article](https://gilead-biostats.github.io/gsm.core/articles/DataAnalysis.html).
+Examples of these yamls can be found above in the `Module Configuration` section, as well as in the [Data Analysis article](https://gilead-public.github.io/gsm.core/articles/DataAnalysis.html).
 
 ### `/3_reporting`
 
 The reporting directory is intended to hold all of the workflows that produce the data that is required for the module outputs. This typically requires the stacking of analysis data from all of the relevant metrics into a single `results` data frame that can be surfaced in a report, or multiple reports. Additionally, any further information that must be taken from the analysis output, such as study/site/group/metric metadata and supporting statistics will be constructed through workflows in this folder.
 
-Examples of these yamls can be found above in the `Module Configuration` section, as well as in the [Data Reporting article](https://gilead-biostats.github.io/gsm.reporting/articles/DataReporting.html).
+Examples of these yamls can be found above in the `Module Configuration` section, as well as in the [Data Reporting article](https://gilead-public.github.io/gsm.reporting/articles/DataReporting.html).
 
 ### `/4_modules`
 
@@ -355,7 +355,7 @@ meta:
   Status: Qualified
   Permission: Users
   Outputs: An html report
-  ExampleURL: https://gilead-biostats.github.io/gsm.kri/report_kri_site.html
+  ExampleURL: https://gilead-public.github.io/gsm.kri/report_kri_site.html
 spec:
   Reporting_Results:
     _all:


### PR DESCRIPTION
## Summary
Updates all direct `Gilead-BioStats` org links to `Gilead-Public` across docs, config, R sources, and metadata files.

## Changes
- Replaced `github.com/Gilead-BioStats` → `github.com/Gilead-Public` for all moved packages.
- Replaced `gilead-biostats.github.io/{pkg}` → `gilead-public.github.io/{pkg}` for all moved packages.
- Updated roxygen comments in 8 R source files — regenerated corresponding `.Rd` files via `devtools::document()`.
- Updated `tests/testthat/helper-cached-workflows.R` org references for `gsm.kri` and `gsm.mapping`.
- Updated `data-raw/simulate_longitudinal_data.R` `pak::pak()` calls.

## Intentional non-updated links
- `gilead-biostats.github.io/gsm.qc` — `gsm.qc` has not moved to `Gilead-Public`.
- `gilead-biostats.github.io/gsm.example` — `gsm.example` has not moved to `Gilead-Public`.
- `README.md` `clindata` link — `clindata` has not moved to `Gilead-Public`.
- `orgs/Gilead-BioStats/projects/41` in `.github/CONTRIBUTING.md` and issue templates — org-level project board.

## Validation
- `grep -rn "Gilead-BioStats\|gilead-biostats.github.io" --exclude-dir=man --exclude-dir=docs .` returns only the intentional keeps listed above.

Closes #172